### PR TITLE
[feat] 카트 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,28 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+sourceSets {
+    named("main") {
+        java.srcDirs("src/main/java", "src/main/generated")
+    }
+}
+
+tasks.named('compileJava') {
+    options.annotationProcessorGeneratedSourcesDirectory = file("$buildDir/generated")
+}
+
+clean {
+    delete file("$buildDir/generated")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zb/ecommerce/config/QuerydslConfig.java
+++ b/src/main/java/com/zb/ecommerce/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.zb.ecommerce.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/zb/ecommerce/config/RedisConfig.java
+++ b/src/main/java/com/zb/ecommerce/config/RedisConfig.java
@@ -12,6 +12,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @RequiredArgsConstructor
 @Configuration
 @EnableRedisRepositories
@@ -29,7 +31,8 @@ public class RedisConfig {
   @Bean
   public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofMinutes(30));
 
     return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
             .cacheDefaults(redisCacheConfiguration)

--- a/src/main/java/com/zb/ecommerce/config/RedisConfig.java
+++ b/src/main/java/com/zb/ecommerce/config/RedisConfig.java
@@ -1,17 +1,12 @@
 package com.zb.ecommerce.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -22,50 +17,22 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-  @Value("${spring.data.redis.host}")
-  private String host;
-
-  @Value("${spring.data.redis.port}")
-  private int port;
-
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setConnectionFactory(factory);
+    return redisTemplate;
+  }
 
   @Bean
-  public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-    RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-            .serializeKeysWith(RedisSerializationContext
-                            .SerializationPair
-                            .fromSerializer(new StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext
-                    .SerializationPair
-                    .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+  public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
-    return RedisCacheManager.RedisCacheManagerBuilder
-            .fromConnectionFactory(redisConnectionFactory)
-            .cacheDefaults(config)
+    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
             .build();
   }
-
-  @Bean
-  public RedisConnectionFactory redisConnectionFactory() {
-    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-    config.setHostName(host);
-    config.setPort(port);
-
-    return new LettuceConnectionFactory(config);
-  }
-
-  @Bean
-  public StringRedisTemplate redisTemplate() {
-    return new StringRedisTemplate(redisConnectionFactory());
-  }
-
-
-//  @Bean
-//  public RedisTemplate<String, Object> redisTemplate() {
-//    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-//    redisTemplate.setKeySerializer(new StringRedisSerializer());
-//    redisTemplate.setValueSerializer(new );
-//    redisTemplate.setConnectionFactory(redisConnectionFactory());
-//    return redisTemplate;
-//  }
 }

--- a/src/main/java/com/zb/ecommerce/config/SecurityConfig.java
+++ b/src/main/java/com/zb/ecommerce/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
             .logout(AbstractHttpConfigurer::disable);
     http
             .authorizeHttpRequests((auth) ->
-                    auth.requestMatchers("/login", "/", "/join", "/email-auth", "/product", "/product/**").permitAll()
+                    auth.requestMatchers("/login", "/", "/join", "/email-auth","/cart","/products","/products/**" ).permitAll()
+                            .requestMatchers("/product", "/product/*").hasRole("ADMIN")
                             .anyRequest().authenticated());
     http
             .addFilterBefore(new JWTFilter(jwtUtil, redisService), LoginFilter.class)

--- a/src/main/java/com/zb/ecommerce/config/SecurityConfig.java
+++ b/src/main/java/com/zb/ecommerce/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
             .logout(AbstractHttpConfigurer::disable);
     http
             .authorizeHttpRequests((auth) ->
-                    auth.requestMatchers("/login", "/", "/join", "/email-auth","/cart","/products","/products/**" ).permitAll()
+                    auth.requestMatchers("/login", "/", "/join", "/email-auth", "/products", "/products/**", "/cart", "/carts").permitAll()
                             .requestMatchers("/product", "/product/*").hasRole("ADMIN")
                             .anyRequest().authenticated());
     http

--- a/src/main/java/com/zb/ecommerce/controller/CartController.java
+++ b/src/main/java/com/zb/ecommerce/controller/CartController.java
@@ -1,0 +1,42 @@
+package com.zb.ecommerce.controller;
+
+import com.zb.ecommerce.domain.dto.CartProductDto;
+import com.zb.ecommerce.domain.form.CartAddForm;
+import com.zb.ecommerce.domain.form.CartUpdateForm;
+import com.zb.ecommerce.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CartController {
+
+  private final CartService cartService;
+
+  @PostMapping("/cart")
+  public ResponseEntity<CartProductDto> addCartProduct(@RequestBody CartAddForm form) {
+    String email = SecurityContextHolder.getContext().getAuthentication().getName();
+    return ResponseEntity.ok(cartService.addProductToCart(email, form));
+  }
+
+  @GetMapping("/carts")
+  public ResponseEntity<List<CartProductDto>> getCartProducts() {
+    String email = SecurityContextHolder.getContext().getAuthentication().getName();
+    return ResponseEntity.ok(cartService.getAllCartProducts(email));
+  }
+
+  @PatchMapping("/cart")
+  public ResponseEntity<CartProductDto> updateCartProduct(@RequestBody CartUpdateForm form) {
+    return ResponseEntity.ok(cartService.updateProductToCart(form));
+  }
+
+  @DeleteMapping("/cart")
+  public ResponseEntity<String> deleteCartProduct(@RequestParam Long id) {
+    cartService.deleteProductToCart(id);
+    return ResponseEntity.ok("카트에 담긴 " + id + "상품이 삭제되었습니다.");
+  }
+}

--- a/src/main/java/com/zb/ecommerce/controller/CartController.java
+++ b/src/main/java/com/zb/ecommerce/controller/CartController.java
@@ -4,6 +4,7 @@ import com.zb.ecommerce.domain.dto.CartProductDto;
 import com.zb.ecommerce.domain.form.CartAddForm;
 import com.zb.ecommerce.domain.form.CartUpdateForm;
 import com.zb.ecommerce.service.CartService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,7 +19,7 @@ public class CartController {
   private final CartService cartService;
 
   @PostMapping("/cart")
-  public ResponseEntity<CartProductDto> addCartProduct(@RequestBody CartAddForm form) {
+  public ResponseEntity<CartProductDto> addCartProduct(@Valid @RequestBody CartAddForm form) {
     String email = SecurityContextHolder.getContext().getAuthentication().getName();
     return ResponseEntity.ok(cartService.addProductToCart(email, form));
   }
@@ -30,7 +31,7 @@ public class CartController {
   }
 
   @PatchMapping("/cart")
-  public ResponseEntity<CartProductDto> updateCartProduct(@RequestBody CartUpdateForm form) {
+  public ResponseEntity<CartProductDto> updateCartProduct(@Valid @RequestBody CartUpdateForm form) {
     return ResponseEntity.ok(cartService.updateProductToCart(form));
   }
 

--- a/src/main/java/com/zb/ecommerce/controller/MemberController.java
+++ b/src/main/java/com/zb/ecommerce/controller/MemberController.java
@@ -19,17 +19,18 @@ public class MemberController {
 
   private final MemberService memberService;
 
-  @GetMapping("/email-auth")
-  public String index(@RequestParam String email,@RequestParam String code) {
-    memberService.emailAuth(email, code);
-    return "회원이 인증되었습니다.";
+
+  @PostMapping("/join")
+  public ResponseEntity<?> addMember(@Valid @RequestBody JoinForm form) {
+    memberService.addMember(form);
+    return ResponseEntity.ok(form.getEmail() + " 으로 회원가입 인증 메일이 전송되었습니다.");
   }
 
 
-  @PostMapping("/join")
-  public ResponseEntity<?> addUser(@Valid @RequestBody JoinForm form) {
-    memberService.addMember(form);
-    return ResponseEntity.ok(form.getEmail()+" 으로 회원가입 인증 메일이 전송되었습니다.");
+  @GetMapping("/email-auth")
+  public String index(@RequestParam String email, @RequestParam String code) {
+    memberService.emailAuth(email, code);
+    return "회원이 인증되었습니다.";
   }
 
 
@@ -49,9 +50,9 @@ public class MemberController {
 
   @PostMapping("/logout")
   public ResponseEntity<String> logout(HttpServletRequest request) {
-    String token  = request.getHeader(HttpHeaders.AUTHORIZATION);
+    String token = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-    if (memberService.logout(token)){
+    if (memberService.logout(token)) {
       return ResponseEntity.ok("로그아웃 완료");
     }
     return ResponseEntity.ok("유효한 토큰이 없습니다.");

--- a/src/main/java/com/zb/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/zb/ecommerce/controller/ProductController.java
@@ -1,18 +1,18 @@
 package com.zb.ecommerce.controller;
 
+import com.zb.ecommerce.domain.dto.PageDto;
 import com.zb.ecommerce.domain.dto.ProductDetailDto;
 import com.zb.ecommerce.domain.dto.ProductDto;
 import com.zb.ecommerce.domain.form.ProductAddForm;
 import com.zb.ecommerce.domain.form.ProductDetailAddForm;
 import com.zb.ecommerce.domain.form.ProductDetailUpdateForm;
 import com.zb.ecommerce.domain.form.ProductUpdateForm;
+import com.zb.ecommerce.domain.type.CategoryType;
 import com.zb.ecommerce.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -38,10 +38,10 @@ public class ProductController {
   }
 
   @GetMapping("/products/search")
-  public ResponseEntity<List<String>> getAllSearchProduct(
+  public ResponseEntity<PageDto> getAllSearchProduct(
           @RequestParam(defaultValue = "0") int page,
-          @RequestParam(defaultValue = "") String keyword,
-          @RequestParam(defaultValue = "OTHERS") String category,
+          @RequestParam(required = false) String keyword,
+          @RequestParam(required = false) CategoryType category,
           @RequestParam(defaultValue = "name") String sort,
           @RequestParam(defaultValue = "true") boolean asc) {
     return ResponseEntity.ok(productService.getAllSearchProduct(

--- a/src/main/java/com/zb/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/zb/ecommerce/controller/ProductController.java
@@ -1,0 +1,98 @@
+package com.zb.ecommerce.controller;
+
+import com.zb.ecommerce.domain.dto.ProductDetailDto;
+import com.zb.ecommerce.domain.dto.ProductDto;
+import com.zb.ecommerce.domain.form.ProductAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailUpdateForm;
+import com.zb.ecommerce.domain.form.ProductUpdateForm;
+import com.zb.ecommerce.service.ProductService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ProductController {
+
+  private final ProductService productService;
+
+  @PostMapping("/product")
+  public ResponseEntity<String> addProduct(@Valid @RequestBody ProductAddForm form) {
+    productService.addProduct(form);
+    return ResponseEntity.ok(form.getName() + " 상품이 추가되었습니다.");
+  }
+
+  @PostMapping("/product/detail")
+  public ResponseEntity<String> addProductDetail(@Valid @RequestBody ProductDetailAddForm form) {
+    productService.addProductDetail(form);
+    return ResponseEntity.ok(form.getCode() + " 의 세부사항이 추가되었습니다.");
+  }
+
+  @GetMapping("/products")
+  public ResponseEntity<List<String>> getAllProduct(@RequestParam(defaultValue = "0") int page) {
+    return ResponseEntity.ok(productService.getAllProduct(page));
+  }
+
+  @GetMapping("/products/detail")
+  public ResponseEntity<ProductDto> getProductDetail(@RequestParam String code) {
+    return ResponseEntity.ok(productService.getProductDetail(code));
+  }
+
+  @GetMapping("/products/sort/name")
+  public ResponseEntity<List<String>> getProductSortName(
+          @RequestParam(defaultValue = "0") int page,
+          @RequestParam(defaultValue = "true") boolean asc) {
+    return ResponseEntity.ok(productService.getAllProductSort( page, "name", asc));
+  }
+
+
+  @GetMapping("/products/sort/price")
+  public ResponseEntity<List<String>> getProductSortPrice(
+          @RequestParam(defaultValue = "0") int page,
+          @RequestParam(defaultValue = "true") boolean asc) {
+    return ResponseEntity.ok(productService.getAllProductSort( page, "price", asc));
+  }
+
+  @GetMapping("/products/sort/category")
+  public ResponseEntity<List<String>> getProductSortCategory(
+          @RequestParam(defaultValue = "0") int page,
+          @RequestParam(defaultValue = "other") String category) {
+    return ResponseEntity.ok(productService.getAllProductSortCategory(page, category));
+  }
+
+  @GetMapping("/products/search/keyword")
+  public ResponseEntity<List<String>> getProductSortKeyword(
+          @RequestParam(defaultValue = "0") int page,
+          @RequestParam String keyword) {
+    return ResponseEntity.ok(productService.getAllProductSearchKeyword(page, keyword));
+  }
+
+  @PatchMapping("/product")
+  public ResponseEntity<ProductDto> updateProduct(
+          @Valid @RequestBody ProductUpdateForm form) {
+    return ResponseEntity.ok(productService.updateProduct(form));
+  }
+
+  @PatchMapping("/product/detail")
+  public ResponseEntity<ProductDetailDto> updateProductDetail(
+          @Valid @RequestBody ProductDetailUpdateForm form) {
+    return ResponseEntity.ok(productService.updateProductDetail(form));
+  }
+
+  @DeleteMapping("/product")
+  public ResponseEntity<ProductDto> deleteProduct(@RequestParam String code) {
+    return ResponseEntity.ok(productService.deleteProduct(code));
+  }
+
+  @DeleteMapping("/product/detail")
+  public ResponseEntity<ProductDetailDto> deleteProductDetail(
+          @Valid @RequestBody ProductDetailUpdateForm form) {
+    return ResponseEntity.ok(productService.deleteProductDetail(form));
+  }
+
+
+}

--- a/src/main/java/com/zb/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/zb/ecommerce/controller/ProductController.java
@@ -32,43 +32,20 @@ public class ProductController {
     return ResponseEntity.ok(form.getCode() + " 의 세부사항이 추가되었습니다.");
   }
 
-  @GetMapping("/products")
-  public ResponseEntity<List<String>> getAllProduct(@RequestParam(defaultValue = "0") int page) {
-    return ResponseEntity.ok(productService.getAllProduct(page));
-  }
-
   @GetMapping("/products/detail")
   public ResponseEntity<ProductDto> getProductDetail(@RequestParam String code) {
     return ResponseEntity.ok(productService.getProductDetail(code));
   }
 
-  @GetMapping("/products/sort/name")
-  public ResponseEntity<List<String>> getProductSortName(
+  @GetMapping("/products/search")
+  public ResponseEntity<List<String>> getAllSearchProduct(
           @RequestParam(defaultValue = "0") int page,
+          @RequestParam(defaultValue = "") String keyword,
+          @RequestParam(defaultValue = "OTHERS") String category,
+          @RequestParam(defaultValue = "name") String sort,
           @RequestParam(defaultValue = "true") boolean asc) {
-    return ResponseEntity.ok(productService.getAllProductSort( page, "name", asc));
-  }
-
-
-  @GetMapping("/products/sort/price")
-  public ResponseEntity<List<String>> getProductSortPrice(
-          @RequestParam(defaultValue = "0") int page,
-          @RequestParam(defaultValue = "true") boolean asc) {
-    return ResponseEntity.ok(productService.getAllProductSort( page, "price", asc));
-  }
-
-  @GetMapping("/products/sort/category")
-  public ResponseEntity<List<String>> getProductSortCategory(
-          @RequestParam(defaultValue = "0") int page,
-          @RequestParam(defaultValue = "other") String category) {
-    return ResponseEntity.ok(productService.getAllProductSortCategory(page, category));
-  }
-
-  @GetMapping("/products/search/keyword")
-  public ResponseEntity<List<String>> getProductSortKeyword(
-          @RequestParam(defaultValue = "0") int page,
-          @RequestParam String keyword) {
-    return ResponseEntity.ok(productService.getAllProductSearchKeyword(page, keyword));
+    return ResponseEntity.ok(productService.getAllSearchProduct(
+            page, keyword, category, sort, asc));
   }
 
   @PatchMapping("/product")

--- a/src/main/java/com/zb/ecommerce/domain/dto/CartProductDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/CartProductDto.java
@@ -1,0 +1,23 @@
+package com.zb.ecommerce.domain.dto;
+
+import com.zb.ecommerce.model.CartProduct;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CartProductDto {
+  private Long id;
+  private String productName;
+  private String size;
+  private Integer quantity;
+
+  public static CartProductDto from(CartProduct cartProduct) {
+    return CartProductDto.builder()
+            .id(cartProduct.getId())
+            .productName(cartProduct.getProduct().getName())
+            .size(cartProduct.getSize())
+            .quantity(cartProduct.getQuantity())
+            .build();
+  }
+}

--- a/src/main/java/com/zb/ecommerce/domain/dto/PageDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/PageDto.java
@@ -8,15 +8,15 @@ import java.util.List;
 
 @Getter
 @Builder
-public class PageDto {
-  private List<?> content;
+public class PageDto<T> {
+  private List<T> content;
   private long totalElements;
   private int totalPages;
   private int number;
   private int size;
 
-  public static PageDto from(Page<?> page) {
-    return PageDto.builder()
+  public static <T> PageDto<T> from(Page<T> page) {
+    return PageDto.<T>builder()
             .content(page.getContent())
             .totalElements(page.getTotalElements())
             .totalPages(page.getTotalPages())

--- a/src/main/java/com/zb/ecommerce/domain/dto/PageDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/PageDto.java
@@ -1,0 +1,27 @@
+package com.zb.ecommerce.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PageDto {
+  private List<?> content;
+  private long totalElements;
+  private int totalPages;
+  private int number;
+  private int size;
+
+  public static PageDto from(Page<?> page) {
+    return PageDto.builder()
+            .content(page.getContent())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .number(page.getNumber())
+            .size(page.getSize())
+            .build();
+  }
+}

--- a/src/main/java/com/zb/ecommerce/domain/dto/ProductDetailDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/ProductDetailDto.java
@@ -1,0 +1,20 @@
+package com.zb.ecommerce.domain.dto;
+
+import com.zb.ecommerce.model.ProductDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductDetailDto {
+  private String size;
+  private Integer quantity;
+
+  public static ProductDetailDto from(ProductDetail detail) {
+    return ProductDetailDto.builder()
+            .size(detail.getSize())
+            .quantity(detail.getQuantity())
+            .build();
+
+  }
+}

--- a/src/main/java/com/zb/ecommerce/domain/dto/ProductDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/ProductDto.java
@@ -1,0 +1,36 @@
+package com.zb.ecommerce.domain.dto;
+
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.model.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDto implements Serializable {
+  private String name;
+  private String code;
+  private CategoryType categoryType;
+  private String description;
+  private Long price;
+  private List<ProductDetailDto> details;
+
+  public static ProductDto from(Product product) {
+    return ProductDto.builder()
+            .name(product.getName())
+            .code(product.getCode())
+            .description(product.getDescription())
+            .price(product.getPrice())
+            .categoryType(product.getCategoryType())
+            .details(product.getDetails().stream().map(ProductDetailDto::from).toList())
+            .build();
+
+  }
+}

--- a/src/main/java/com/zb/ecommerce/domain/dto/ProductDto.java
+++ b/src/main/java/com/zb/ecommerce/domain/dto/ProductDto.java
@@ -31,6 +31,16 @@ public class ProductDto implements Serializable {
             .categoryType(product.getCategoryType())
             .details(product.getDetails().stream().map(ProductDetailDto::from).toList())
             .build();
+  }
+
+  public static ProductDto fromWithoutDetail(Product product) {
+    return ProductDto.builder()
+            .name(product.getName())
+            .code(product.getCode())
+            .description(product.getDescription())
+            .price(product.getPrice())
+            .categoryType(product.getCategoryType())
+            .build();
 
   }
 }

--- a/src/main/java/com/zb/ecommerce/domain/form/CartAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/CartAddForm.java
@@ -1,0 +1,17 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartAddForm {
+  @NotBlank(message = "상품 코드를 입력해주세요")
+  private String productCode;
+  @NotBlank(message = "상품 사이즈를 입력해주세요")
+  private String size;  
+  @Pattern(regexp = "^.{0}$|^[1-9][0-9]*$", message = "숫자만 입력해주세요")
+  private String quantity;
+}

--- a/src/main/java/com/zb/ecommerce/domain/form/CartAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/CartAddForm.java
@@ -1,7 +1,7 @@
 package com.zb.ecommerce.domain.form;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ public class CartAddForm {
   @NotBlank(message = "상품 코드를 입력해주세요")
   private String productCode;
   @NotBlank(message = "상품 사이즈를 입력해주세요")
-  private String size;  
-  @Pattern(regexp = "^.{0}$|^[1-9][0-9]*$", message = "숫자만 입력해주세요")
-  private String quantity;
+  private String size;
+  @Min(value = 1, message = "1이상의 숫자만 입력해주세요")
+  private Integer quantity;
 }

--- a/src/main/java/com/zb/ecommerce/domain/form/CartUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/CartUpdateForm.java
@@ -1,0 +1,17 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartUpdateForm {
+  @Pattern(regexp = "^[0-9]+$", message = "숫자를 입력해주세요")
+  private Long id;
+  @NotBlank(message = "상품 사이즈를 입력해주세요")
+  private String size;
+  @Pattern(regexp = "^[1-9][0-9]*$", message = "숫자를 입력해주세요")
+  private String quantity;
+}

--- a/src/main/java/com/zb/ecommerce/domain/form/CartUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/CartUpdateForm.java
@@ -1,5 +1,6 @@
 package com.zb.ecommerce.domain.form;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -12,6 +13,6 @@ public class CartUpdateForm {
   private Long id;
   @NotBlank(message = "상품 사이즈를 입력해주세요")
   private String size;
-  @Pattern(regexp = "^[1-9][0-9]*$", message = "숫자를 입력해주세요")
-  private String quantity;
+  @Min(value = 1, message = "1이상의 숫자만 입력해주세요")
+  private Integer quantity;
 }

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductAddForm.java
@@ -1,0 +1,22 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductAddForm {
+  @NotBlank
+  private String name;
+  @NotBlank
+  private String code;
+  @NotBlank
+  @Pattern(regexp = "^[a-zA-Z]+$", message = "숫자는 입력할 수 없습니다.")
+  private String category;
+  private String description;
+  @NotBlank
+  @Pattern(regexp = "^[0-9]{4,}$", message = "1000원 이상의 숫자만 입력해주세요")
+  private String price;
+}

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductAddForm.java
@@ -1,6 +1,8 @@
 package com.zb.ecommerce.domain.form;
 
+import com.zb.ecommerce.domain.type.CategoryType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +14,8 @@ public class ProductAddForm {
   private String name;
   @NotBlank
   private String code;
-  @NotBlank
-  @Pattern(regexp = "^[a-zA-Z]+$", message = "숫자는 입력할 수 없습니다.")
-  private String category;
+  @NotNull
+  private CategoryType category;
   private String description;
   @NotBlank
   @Pattern(regexp = "^[0-9]{4,}$", message = "1000원 이상의 숫자만 입력해주세요")

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductDetailAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductDetailAddForm.java
@@ -1,5 +1,6 @@
 package com.zb.ecommerce.domain.form;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -13,7 +14,6 @@ public class ProductDetailAddForm {
   @NotBlank
   @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "사이즈를 입력해주세요")
   private String size;
-  @NotBlank
-  @Pattern(regexp = "^[1-9][0-9]*$", message = "1개 이상의 숫자만 입력해주세요")
-  private String quantity;
+  @Min(value = 1, message = "1개 이상의 숫자만 입력해주세요")
+  private Integer quantity;
 }

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductDetailAddForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductDetailAddForm.java
@@ -1,0 +1,19 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductDetailAddForm {
+  @NotBlank
+  private String code;
+  @NotBlank
+  @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "사이즈를 입력해주세요")
+  private String size;
+  @NotBlank
+  @Pattern(regexp = "^[1-9][0-9]*$", message = "1개 이상의 숫자만 입력해주세요")
+  private String quantity;
+}

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductDetailUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductDetailUpdateForm.java
@@ -1,0 +1,18 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductDetailUpdateForm {
+  @NotBlank(message = "코드를 입력해주세요")
+  private String code;
+  @NotBlank(message = "수정할 사이즈를 입력해주세요")
+  private String size;
+  private String changeSize;
+  @Pattern(regexp = "^.{0}$|^[0-9]+$", message = "숫자만 입력해주세요")
+  private String quantity;
+}

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductDetailUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductDetailUpdateForm.java
@@ -1,7 +1,7 @@
 package com.zb.ecommerce.domain.form;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,6 +13,6 @@ public class ProductDetailUpdateForm {
   @NotBlank(message = "수정할 사이즈를 입력해주세요")
   private String size;
   private String changeSize;
-  @Pattern(regexp = "^.{0}$|^[0-9]+$", message = "숫자만 입력해주세요")
-  private String quantity;
+  @Min(value = 1, message = "1이상의 숫자만 입력해주세요")
+  private Integer quantity;
 }

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductUpdateForm.java
@@ -1,5 +1,6 @@
 package com.zb.ecommerce.domain.form;
 
+import com.zb.ecommerce.domain.type.CategoryType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -13,7 +14,7 @@ public class ProductUpdateForm {
   @NotBlank(message = "코드를 입력해주세요.")
   private String code;
   private String changeCode;
-  private String categoryType;
+  private CategoryType categoryType;
   private String description;
   @Pattern(regexp = "^.{0}$|^.{4,}$", message = "1000원 이상의 숫자만 입력해주세요")
   private String price;

--- a/src/main/java/com/zb/ecommerce/domain/form/ProductUpdateForm.java
+++ b/src/main/java/com/zb/ecommerce/domain/form/ProductUpdateForm.java
@@ -1,0 +1,20 @@
+package com.zb.ecommerce.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductUpdateForm {
+
+  private String name;
+  @NotBlank(message = "코드를 입력해주세요.")
+  private String code;
+  private String changeCode;
+  private String categoryType;
+  private String description;
+  @Pattern(regexp = "^.{0}$|^.{4,}$", message = "1000원 이상의 숫자만 입력해주세요")
+  private String price;
+}

--- a/src/main/java/com/zb/ecommerce/domain/type/CategoryType.java
+++ b/src/main/java/com/zb/ecommerce/domain/type/CategoryType.java
@@ -1,0 +1,22 @@
+package com.zb.ecommerce.domain.type;
+
+public enum CategoryType {
+  TOP,
+  BOTTOM,
+  SHOES,
+  SOCKS,
+  BELT,
+  HAT,
+  ACCESSORIES,
+  OTHERS;
+
+  public static CategoryType fromString(String category) {
+    String s = category.toUpperCase();
+    for (CategoryType type : CategoryType.values()) {
+      if (type.toString().equals(s)) {
+        return type;
+      }
+    }
+    return OTHERS;
+  }
+}

--- a/src/main/java/com/zb/ecommerce/domain/type/MemberType.java
+++ b/src/main/java/com/zb/ecommerce/domain/type/MemberType.java
@@ -1,6 +1,6 @@
 package com.zb.ecommerce.domain.type;
 
 public enum MemberType {
-  ADMIN,
-  MEMBER
+  ROLE_ADMIN,
+  ROLE_MEMBER
 }

--- a/src/main/java/com/zb/ecommerce/exception/ErrorCode.java
+++ b/src/main/java/com/zb/ecommerce/exception/ErrorCode.java
@@ -25,6 +25,17 @@ public enum ErrorCode {
   SEND_EMAIL_FAIL(HttpStatus.BAD_REQUEST, "이메일 전송에 실패했습니댜."),
   NOT_ALLOW_BLANK(HttpStatus.BAD_REQUEST, "이메일값이 비어있습니다."),
 
+
+
+  ALREADY_ADDED_PRODUCT(HttpStatus.BAD_REQUEST, "이미 추가된 상품입니다."),
+  NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+  ALREADY_ADDED_SIZE(HttpStatus.BAD_REQUEST, "이미 추가된 사이즈입니다."),
+  NOT_FOUND_SIZE(HttpStatus.BAD_REQUEST, "해당 사이즈를 찾을 수 없습니다."),
+  NOT_ENOUGH_PRODUCT(HttpStatus.BAD_REQUEST, "상품 갯수가 충분하지 않습니다."),
+
+
+  NOT_FOUND_CART_PRODUCT(HttpStatus.BAD_REQUEST, "카트에 담긴 상품을 찾을 수 없습니다."),
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/zb/ecommerce/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/ecommerce/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.zb.ecommerce.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,6 +14,16 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<String> httpMessageNotReadableExceptionHandler(HttpMessageNotReadableException e) {
+    log.info("HttpMessageNotReadableException is occurred : {}", e.getMessage());
+
+    return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body("카테고리 타입을 확인해주세요");
+  }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Map<String, String>> validException(MethodArgumentNotValidException e) {

--- a/src/main/java/com/zb/ecommerce/model/CartProduct.java
+++ b/src/main/java/com/zb/ecommerce/model/CartProduct.java
@@ -1,0 +1,24 @@
+package com.zb.ecommerce.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+public class CartProduct {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  private Product product;
+  private String size;
+  private Integer quantity;
+}

--- a/src/main/java/com/zb/ecommerce/model/Member.java
+++ b/src/main/java/com/zb/ecommerce/model/Member.java
@@ -4,6 +4,8 @@ import com.zb.ecommerce.domain.type.MemberType;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -25,4 +27,6 @@ public class Member extends BaseEntity{
   @Enumerated(EnumType.STRING)
   private MemberType role;
   private Boolean isEmailVerified;
+  @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<CartProduct> cart;
 }

--- a/src/main/java/com/zb/ecommerce/model/Member.java
+++ b/src/main/java/com/zb/ecommerce/model/Member.java
@@ -27,6 +27,6 @@ public class Member extends BaseEntity{
   @Enumerated(EnumType.STRING)
   private MemberType role;
   private Boolean isEmailVerified;
-  @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<CartProduct> cart;
 }

--- a/src/main/java/com/zb/ecommerce/model/Product.java
+++ b/src/main/java/com/zb/ecommerce/model/Product.java
@@ -5,6 +5,7 @@ import com.zb.ecommerce.domain.type.CategoryType;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -25,7 +26,7 @@ public class Product extends BaseEntity {
   private CategoryType categoryType;
   private String description;
   private Long price;
-  @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<ProductDetail> details;
 
   public static Product from(ProductAddForm form) {
@@ -36,6 +37,7 @@ public class Product extends BaseEntity {
             .categoryType(form.getCategory())
             .description(form.getDescription())
             .price(Long.valueOf(form.getPrice()))
+            .details(new ArrayList<>())
             .build();
   }
 }

--- a/src/main/java/com/zb/ecommerce/model/Product.java
+++ b/src/main/java/com/zb/ecommerce/model/Product.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Setter
-public class Product extends BaseEntity{
+public class Product extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -28,13 +28,12 @@ public class Product extends BaseEntity{
   @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<ProductDetail> details;
 
-  public static Product from(ProductAddForm form){
-    CategoryType categoryTypeFromForm = CategoryType.fromString(form.getCategory());
+  public static Product from(ProductAddForm form) {
 
     return Product.builder()
             .name(form.getName())
             .code(form.getCode())
-            .categoryType(categoryTypeFromForm)
+            .categoryType(form.getCategory())
             .description(form.getDescription())
             .price(Long.valueOf(form.getPrice()))
             .build();

--- a/src/main/java/com/zb/ecommerce/model/Product.java
+++ b/src/main/java/com/zb/ecommerce/model/Product.java
@@ -1,0 +1,42 @@
+package com.zb.ecommerce.model;
+
+import com.zb.ecommerce.domain.form.ProductAddForm;
+import com.zb.ecommerce.domain.type.CategoryType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+public class Product extends BaseEntity{
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(unique = true)
+  private String name;
+  @Column(unique = true)
+  private String code;
+  @Enumerated(EnumType.STRING)
+  private CategoryType categoryType;
+  private String description;
+  private Long price;
+  @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<ProductDetail> details;
+
+  public static Product from(ProductAddForm form){
+    CategoryType categoryTypeFromForm = CategoryType.fromString(form.getCategory());
+
+    return Product.builder()
+            .name(form.getName())
+            .code(form.getCode())
+            .categoryType(categoryTypeFromForm)
+            .description(form.getDescription())
+            .price(Long.valueOf(form.getPrice()))
+            .build();
+  }
+}

--- a/src/main/java/com/zb/ecommerce/model/ProductDetail.java
+++ b/src/main/java/com/zb/ecommerce/model/ProductDetail.java
@@ -26,7 +26,7 @@ public class ProductDetail extends BaseEntity{
     return ProductDetail.builder()
             .product(product)
             .size(form.getSize().toUpperCase())
-            .quantity(Integer.parseInt(form.getQuantity()))
+            .quantity(form.getQuantity())
             .build();
   }
 }

--- a/src/main/java/com/zb/ecommerce/model/ProductDetail.java
+++ b/src/main/java/com/zb/ecommerce/model/ProductDetail.java
@@ -1,0 +1,32 @@
+package com.zb.ecommerce.model;
+
+import com.zb.ecommerce.domain.form.ProductDetailAddForm;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+public class ProductDetail extends BaseEntity{
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  private Product product;
+  @Column(unique = true)
+  private String size;
+  private Integer quantity;
+
+  public static ProductDetail from(ProductDetailAddForm form, Product product) {
+    return ProductDetail.builder()
+            .product(product)
+            .size(form.getSize().toUpperCase())
+            .quantity(Integer.parseInt(form.getQuantity()))
+            .build();
+  }
+}

--- a/src/main/java/com/zb/ecommerce/repository/CartProductRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/CartProductRepository.java
@@ -1,0 +1,16 @@
+package com.zb.ecommerce.repository;
+
+import com.zb.ecommerce.model.CartProduct;
+import com.zb.ecommerce.model.Member;
+import com.zb.ecommerce.model.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CartProductRepository extends JpaRepository<CartProduct, Long> {
+
+  Optional<CartProduct> findByMemberAndProductAndSize(Member member, Product product, String size);
+
+}

--- a/src/main/java/com/zb/ecommerce/repository/MemberRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long> , MemberRepositoryCustom{
 
   boolean existsByEmail(String email);
 

--- a/src/main/java/com/zb/ecommerce/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/zb/ecommerce/repository/MemberRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.zb.ecommerce.repository;
+
+import com.zb.ecommerce.model.Member;
+
+public interface MemberRepositoryCustom {
+
+  Member searchByEmail(String email);
+}

--- a/src/main/java/com/zb/ecommerce/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/zb/ecommerce/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.zb.ecommerce.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.exception.ErrorCode;
+import com.zb.ecommerce.model.Member;
+import lombok.RequiredArgsConstructor;
+
+import static com.zb.ecommerce.model.QCartProduct.cartProduct;
+import static com.zb.ecommerce.model.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Member searchByEmail(String email) {
+    Member searchMember = queryFactory.selectFrom(member)
+            .leftJoin(member.cart, cartProduct).fetchJoin()
+            .where(member.email.eq(email))
+            .fetchOne();
+
+    if (searchMember == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_MEMBER);
+    }
+    return searchMember;
+  }
+}

--- a/src/main/java/com/zb/ecommerce/repository/ProductDetailRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductDetailRepository.java
@@ -1,0 +1,10 @@
+package com.zb.ecommerce.repository;
+
+import com.zb.ecommerce.model.ProductDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductDetailRepository extends JpaRepository<ProductDetail, Long> {
+
+}

--- a/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
@@ -1,0 +1,27 @@
+package com.zb.ecommerce.repository;
+
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.model.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+  Page<Product> findAll(Pageable pageable);
+
+  Page<Product> findAllByCategoryType(CategoryType categoryType, Pageable pageable);
+
+  Optional<Product> findByCode(String code);
+
+  boolean existsByCode(String code);
+
+  Page<Product> findByNameContainingOrDescriptionContaining(String name, String description, Pageable pageable);
+
+  boolean existsByName(String name);
+
+  void deleteByCode(String code);
+}

--- a/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
@@ -1,9 +1,6 @@
 package com.zb.ecommerce.repository;
 
-import com.zb.ecommerce.domain.type.CategoryType;
 import com.zb.ecommerce.model.Product;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,17 +8,13 @@ import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
-  Page<Product> findAll(Pageable pageable);
-
-  Page<Product> findAllByCategoryType(CategoryType categoryType, Pageable pageable);
 
   Optional<Product> findByCode(String code);
 
   boolean existsByCode(String code);
 
-  Page<Product> findByNameContainingOrDescriptionContaining(String name, String description, Pageable pageable);
-
   boolean existsByName(String name);
 
   void deleteByCode(String code);
+
 }

--- a/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductRepository.java
@@ -4,12 +4,8 @@ import com.zb.ecommerce.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
-
-  Optional<Product> findByCode(String code);
+public interface ProductRepository extends JpaRepository<Product, Long> , ProductRepositoryCustom{
 
   boolean existsByCode(String code);
 

--- a/src/main/java/com/zb/ecommerce/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.zb.ecommerce.repository;
+
+import com.zb.ecommerce.domain.dto.ProductDto;
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.model.Product;
+import org.springframework.data.domain.Page;
+
+public interface ProductRepositoryCustom {
+  Page<ProductDto> searchAll(int page, String keyword,
+                             CategoryType category, String sortType, boolean asc);
+
+  Product searchByCode(String code);
+
+}

--- a/src/main/java/com/zb/ecommerce/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/zb/ecommerce/repository/ProductRepositoryCustomImpl.java
@@ -1,0 +1,82 @@
+package com.zb.ecommerce.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.ecommerce.domain.dto.ProductDto;
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.model.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.zb.ecommerce.exception.ErrorCode.NOT_FOUND_PRODUCT;
+import static com.zb.ecommerce.model.QProduct.product;
+import static com.zb.ecommerce.model.QProductDetail.productDetail;
+
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<ProductDto> searchAll(int page,
+                                    String keyword,
+                                    CategoryType category,
+                                    String sortType,
+                                    boolean asc) {
+
+    Pageable pageable = PageRequest.of(page, 20);
+
+    OrderSpecifier<?> querySort = product.name.asc();
+    if (sortType.equals("price") && asc) {
+      querySort = product.price.asc();
+    } else if (sortType.equals("price")) {
+      querySort = product.price.desc();
+    } else if (!asc) {
+      querySort = product.name.desc();
+    }
+
+    List<Product> products = queryFactory.selectFrom(product)
+            .where(keyword != null && !keyword.isEmpty() ?
+                    product.name.contains(keyword).or(product.description.contains(keyword))
+                    : null)
+            .where(category != null ? product.categoryType.eq(category) : null)
+            .leftJoin(product.details, productDetail)
+            .orderBy(querySort)
+            .limit(pageable.getPageSize())
+            .offset(pageable.getOffset())
+            .fetch();
+
+    long total = products.size();
+
+    List<ProductDto> productDtoList = products.stream()
+            .map(ProductDto::fromWithoutDetail)
+            .toList();
+
+    return new PageImpl<>(productDtoList, pageable, total);
+  }
+
+
+  @Override
+  public Product searchByCode(String code){
+    Product searchProduct = queryFactory
+            .selectFrom(product)
+            .leftJoin(product.details, productDetail).fetchJoin()
+            .where(product.code.eq(code))
+            .fetchOne();
+
+    if (searchProduct == null) {
+      throw new CustomException(NOT_FOUND_PRODUCT);
+    }
+
+    return searchProduct;
+  }
+
+
+
+}

--- a/src/main/java/com/zb/ecommerce/security/JWTUtil.java
+++ b/src/main/java/com/zb/ecommerce/security/JWTUtil.java
@@ -22,7 +22,6 @@ public class JWTUtil {
   public JWTUtil(@Value("${jwt.secretkey}") String secret) {
     secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
             Jwts.SIG.HS256.key().build().getAlgorithm());
-
   }
 
 

--- a/src/main/java/com/zb/ecommerce/service/CartService.java
+++ b/src/main/java/com/zb/ecommerce/service/CartService.java
@@ -1,0 +1,120 @@
+package com.zb.ecommerce.service;
+
+import com.zb.ecommerce.domain.dto.CartProductDto;
+import com.zb.ecommerce.domain.form.CartAddForm;
+import com.zb.ecommerce.domain.form.CartUpdateForm;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.exception.ErrorCode;
+import com.zb.ecommerce.model.CartProduct;
+import com.zb.ecommerce.model.Member;
+import com.zb.ecommerce.model.Product;
+import com.zb.ecommerce.model.ProductDetail;
+import com.zb.ecommerce.repository.CartProductRepository;
+import com.zb.ecommerce.repository.MemberRepository;
+import com.zb.ecommerce.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+  private final MemberRepository memberRepository;
+  private final CartProductRepository cartProductRepository;
+  private final ProductRepository productRepository;
+
+  @CacheEvict(value = "cart", allEntries = true)
+  @Transactional
+  public CartProductDto addProductToCart(String email, CartAddForm form) {
+    Member member = findMemberByEmail(email);
+    Product product = findProductByCode(form.getProductCode());
+    int quantity = 1;
+    if (form.getQuantity() != null) {
+      quantity = Integer.parseInt(form.getQuantity());
+    }
+
+    String size = form.getSize().toUpperCase();
+    ProductDetail productDetail = product.getDetails().stream()
+            .filter(detail -> detail.getSize().equals(size))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SIZE));
+
+    boolean isExist = member.getCart().stream()
+            .anyMatch(item -> Objects.equals(item.getProduct().getId(), product.getId()));
+
+    if (isExist) {
+      CartProduct cartProduct = cartProductRepository.findByMemberAndProductAndSize(member, product, size)
+              .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CART_PRODUCT));
+      if (cartProduct.getQuantity() + quantity > productDetail.getQuantity()) {
+        throw new CustomException(ErrorCode.NOT_ENOUGH_PRODUCT);
+      }
+      cartProduct.setQuantity(cartProduct.getQuantity() + quantity);
+      return CartProductDto.from(cartProduct);
+    }
+
+    return CartProductDto.from(cartProductRepository.save(CartProduct.builder()
+            .member(member)
+            .product(product)
+            .size(size)
+            .quantity(quantity)
+            .build()));
+  }
+
+  @Cacheable(value = "cart", key = "'cart-all-'+#email")
+  public List<CartProductDto> getAllCartProducts(String email) {
+    Member member = findMemberByEmail(email);
+
+    return member.getCart().stream()
+            .map(CartProductDto::from)
+            .toList();
+  }
+
+  @Transactional
+  @CacheEvict(value = "cart", allEntries = true)
+  public CartProductDto updateProductToCart(CartUpdateForm form) {
+    CartProduct cartProduct = cartProductRepository.findById(form.getId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CART_PRODUCT));
+    Product product = cartProduct.getProduct();
+    String size = form.getSize().toUpperCase();
+    ProductDetail productDetail = product.getDetails().stream()
+            .filter(detail -> detail.getSize().equals(size))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SIZE));
+
+    int quantity = Integer.parseInt(form.getQuantity());
+
+    if (quantity > productDetail.getQuantity()) {
+      throw new CustomException(ErrorCode.NOT_ENOUGH_PRODUCT);
+    }
+    cartProduct.setQuantity(quantity);
+    return CartProductDto.from(cartProduct);
+  }
+
+  @Transactional
+  @CacheEvict(value = "cart", allEntries = true)
+  public void deleteProductToCart(Long id) {
+    boolean isExist = cartProductRepository.existsById(id);
+    if (!isExist) {
+      throw new CustomException(ErrorCode.NOT_FOUND_CART_PRODUCT);
+    }
+    cartProductRepository.deleteById(id);
+  }
+
+
+  private Member findMemberByEmail(String email) {
+    return memberRepository.findByEmail(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+  }
+
+  private Product findProductByCode(String code) {
+    return productRepository.findByCode(code)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
+  }
+
+}

--- a/src/main/java/com/zb/ecommerce/service/MemberService.java
+++ b/src/main/java/com/zb/ecommerce/service/MemberService.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.zb.ecommerce.exception.ErrorCode.*;
@@ -158,6 +159,7 @@ public class MemberService {
             .addressDetail(form.getAddressDetail())
             .role(MemberType.ROLE_MEMBER)
             .isEmailVerified(false)
+            .cart(new ArrayList<>())
             .build();
   }
 

--- a/src/main/java/com/zb/ecommerce/service/ProductService.java
+++ b/src/main/java/com/zb/ecommerce/service/ProductService.java
@@ -1,0 +1,214 @@
+package com.zb.ecommerce.service;
+
+import com.zb.ecommerce.domain.dto.ProductDetailDto;
+import com.zb.ecommerce.domain.dto.ProductDto;
+import com.zb.ecommerce.domain.form.ProductAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailUpdateForm;
+import com.zb.ecommerce.domain.form.ProductUpdateForm;
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.exception.ErrorCode;
+import com.zb.ecommerce.model.Product;
+import com.zb.ecommerce.model.ProductDetail;
+import com.zb.ecommerce.repository.ProductDetailRepository;
+import com.zb.ecommerce.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+  private final ProductRepository productRepository;
+  private final ProductDetailRepository productDetailRepository;
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  public void addProduct(ProductAddForm form) {
+    boolean isExist = productRepository.existsByCode(form.getCode());
+
+    if (isExist) {
+      throw new CustomException(ErrorCode.ALREADY_ADDED_PRODUCT);
+    }
+
+    productRepository.save(Product.from(form));
+  }
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  public void addProductDetail(ProductDetailAddForm form) {
+    Product product = findProductByCode(form.getCode());
+
+    if (product.getDetails() != null){
+      List<ProductDetail> details = product.getDetails();
+      for (ProductDetail detail : details) {
+        if (detail.getSize().equals(form.getSize().toUpperCase())) {
+          throw new CustomException(ErrorCode.ALREADY_ADDED_SIZE);
+        }
+      }
+    }
+
+    productDetailRepository.save(ProductDetail.from(form, product));
+  }
+
+  @Cacheable(value = "products", key = "'all-'+#page")
+  public List<String> getAllProduct(int page) {
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageableSetup = PageRequest.of(page, 20, sort);
+    Page<Product> productPage = productRepository.findAll(pageableSetup);
+
+    if (productPage.isEmpty()) {
+      return null;
+    }
+
+    List<String> productNames = productPage.getContent().stream()
+            .filter(product -> product.getDetails().stream().anyMatch(detail -> detail.getQuantity() > 0))
+            .map(product -> String.format(String.format("%s : %,d", product.getName(), product.getPrice())))
+            .collect(Collectors.toCollection(ArrayList::new));
+    if (productNames.size() == productPage.getContent().size()) {
+      return productNames;
+    }
+    productNames.addAll(productPage.getContent().stream()
+            .filter(product -> product.getDetails().stream().allMatch(detail -> detail.getQuantity() == 0))
+            .map(product -> String.format(String.format("(품절)%s : %,d", product.getName(), product.getPrice())))
+            .toList());
+
+    return productNames;
+  }
+
+  @Cacheable(value = "product", key = "'product-detail-'+#code")
+  public ProductDto getProductDetail(String code) {
+    Product product = findProductByCode(code);
+    return ProductDto.from(product);
+  }
+
+  @Cacheable(value = "products", key = "'all-'+#type+'-'+#page+'-'+#asc")
+  public List<String> getAllProductSort(int page, String type, boolean asc) {
+      type = type.toLowerCase();
+    if (!type.equals("price") && !type.equals("name")) {
+      type = "name";
+    }
+    Sort sort = Sort.by(Sort.Direction.ASC, type);
+    if (!asc) {
+      sort = Sort.by(Sort.Direction.DESC, type);
+    }
+    Pageable pageableSetup = PageRequest.of(page, 20, sort);
+    Page<Product> productPage = productRepository.findAll(pageableSetup);
+    return productPage.getContent().stream()
+            .map(product -> String.format("%s : %,d원", product.getName(), product.getPrice()))
+            .toList();
+  }
+
+  @Cacheable(value = "products", key = "'all-category-'+#page+'-'+#category")
+  public List<String> getAllProductSortCategory(int page, String category) {
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageableSetup = PageRequest.of(page, 20, sort);
+
+    Page<Product> productPage = productRepository.findAllByCategoryType(
+            CategoryType.fromString(category), pageableSetup);
+
+    return productPage.getContent().stream()
+            .map(product -> String.format("%s : %,d원", product.getName(), product.getPrice()))
+            .toList();
+  }
+
+  @Cacheable(value = "products", key = "'all-keyword-'+#page+'-'+#keyword")
+  public List<String> getAllProductSearchKeyword(int page, String keyword) {
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageableSetup = PageRequest.of(page, 20, sort);
+    Page<Product> productPage = productRepository.findByNameContainingOrDescriptionContaining(
+            keyword, keyword, pageableSetup);
+    return productPage.getContent().stream()
+            .map(product -> String.format("%s : %,d원", product.getName(), product.getPrice()))
+            .toList();
+  }
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  @Transactional
+  public ProductDto updateProduct(ProductUpdateForm form) {
+    Product product = findProductByCode(form.getCode());
+    setProductFromForm(form, product);
+    return ProductDto.from(product);
+  }
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  @Transactional
+  public ProductDetailDto updateProductDetail(ProductDetailUpdateForm form) {
+    Product product = findProductByCode(form.getCode());
+    ProductDetail detail = findProductDetailByProductAndSize(product, form.getSize());
+
+    setProductDetailFromForm(form, detail, product);
+    return ProductDetailDto.from(detail);
+  }
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  @Transactional
+  public ProductDto deleteProduct(String code) {
+    Product product = findProductByCode(code);
+    productRepository.deleteByCode(code);
+    return ProductDto.from(product);
+  }
+
+  @CacheEvict(value = {"product","products"}, allEntries = true)
+  @Transactional
+  public ProductDetailDto deleteProductDetail(ProductDetailUpdateForm form) {
+    Product product = findProductByCode(form.getCode());
+    ProductDetail detail = findProductDetailByProductAndSize(product, form.getSize());
+    productDetailRepository.delete(detail);
+    return ProductDetailDto.from(detail);
+  }
+
+  private void setProductFromForm(ProductUpdateForm form, Product product) {
+    if (form.getName() != null && !productRepository.existsByName(form.getName())){
+      product.setName(form.getName());
+    }
+    if (form.getChangeCode() != null && !productRepository.existsByCode(form.getCode())){
+      product.setCode(form.getChangeCode());
+    }
+    if (form.getDescription() != null){
+      product.setDescription(form.getDescription());
+    }
+    if (form.getPrice() != null){
+      product.setPrice(Long.valueOf(form.getPrice()));
+    }
+    if (form.getCategoryType() != null){
+      product.setCategoryType(CategoryType.fromString(form.getCategoryType()));
+    }
+  }
+
+  private void setProductDetailFromForm(ProductDetailUpdateForm form, ProductDetail detail, Product product) {
+    if (form.getChangeSize() != null){
+      for (ProductDetail productDetail : product.getDetails()){
+        if (productDetail.getSize().equals(form.getChangeSize())){
+          throw new CustomException(ErrorCode.ALREADY_ADDED_SIZE);
+        }
+      }
+      detail.setSize(form.getChangeSize().toUpperCase());
+    }
+    if (form.getQuantity() != null) {
+      detail.setQuantity(Integer.valueOf(form.getQuantity()));
+    }
+  }
+
+  private ProductDetail findProductDetailByProductAndSize(Product product, String size) {
+    return product.getDetails().stream()
+            .filter(detail -> detail.getSize().equals(size.toUpperCase()))
+            .findFirst()
+            .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_SIZE));
+  }
+
+  private Product findProductByCode(String code) {
+    return productRepository.findByCode(code)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
+  }
+}

--- a/src/main/java/com/zb/ecommerce/service/ProductService.java
+++ b/src/main/java/com/zb/ecommerce/service/ProductService.java
@@ -41,7 +41,6 @@ public class ProductService {
 
   public void addProductDetail(ProductDetailAddForm form) {
     Product product = productRepository.searchByCode(form.getCode());
-
     if (!product.getDetails().isEmpty()) {
       List<ProductDetail> details = product.getDetails();
       for (ProductDetail detail : details) {

--- a/src/main/java/com/zb/ecommerce/service/ProductService.java
+++ b/src/main/java/com/zb/ecommerce/service/ProductService.java
@@ -1,7 +1,6 @@
 package com.zb.ecommerce.service;
 
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.ecommerce.domain.dto.PageDto;
 import com.zb.ecommerce.domain.dto.ProductDetailDto;
 import com.zb.ecommerce.domain.dto.ProductDto;
 import com.zb.ecommerce.domain.form.ProductAddForm;
@@ -21,13 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.zb.ecommerce.model.QProduct.product;
+import static com.zb.ecommerce.exception.ErrorCode.NOT_FOUND_SIZE;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
-  private final JPAQueryFactory queryFactory;
   private final ProductRepository productRepository;
   private final ProductDetailRepository productDetailRepository;
 
@@ -42,9 +40,9 @@ public class ProductService {
   }
 
   public void addProductDetail(ProductDetailAddForm form) {
-    Product product = findProductByCode(form.getCode());
+    Product product = productRepository.searchByCode(form.getCode());
 
-    if (product.getDetails() != null) {
+    if (!product.getDetails().isEmpty()) {
       List<ProductDetail> details = product.getDetails();
       for (ProductDetail detail : details) {
         if (detail.getSize().equals(form.getSize().toUpperCase())) {
@@ -57,90 +55,61 @@ public class ProductService {
   }
 
   public ProductDto getProductDetail(String code) {
-    Product product = findProductByCode(code);
+    Product product = productRepository.searchByCode(code);
     return ProductDto.from(product);
   }
 
-  public List<String> getAllSearchProduct(int page, String keyword,
-                                          String category, String sortType, boolean asc) {
+  public PageDto getAllSearchProduct(int page,
+                                     String keyword,
+                                     CategoryType category,
+                                     String sortType,
+                                     boolean asc) {
 
-    List<Product> products;
-    OrderSpecifier<?> sort = product.name.asc();
-    if (sortType.equals("price") && asc) {
-      sort = product.price.asc();
-    } else if (sortType.equals("price")) {
-      sort = product.price.desc();
-    } else if (!asc) {
-      sort = product.name.desc();
-    }
-
-    CategoryType categoryType = CategoryType.fromString(category);
-
-    if (!keyword.isEmpty() && categoryType != CategoryType.OTHERS) {
-      products = queryFactory.selectFrom(product)
-              .where(product.name.contains(keyword))
-              .where(product.description.contains(keyword))
-              .where(product.categoryType.eq(categoryType))
-              .orderBy(sort)
-              .limit(20)
-              .offset(page)
-              .fetch();
-    } else if (!keyword.isEmpty()) {
-      products = queryFactory.selectFrom(product)
-              .where(product.name.contains(keyword))
-              .where(product.description.contains(keyword))
-              .orderBy(sort)
-              .limit(20)
-              .offset(page)
-              .fetch();
-    } else if (categoryType != CategoryType.OTHERS) {
-      products = queryFactory.selectFrom(product)
-              .where(product.categoryType.eq(categoryType))
-              .orderBy(sort)
-              .limit(20)
-              .offset(page)
-              .fetch();
-    } else {
-      products = queryFactory.selectFrom(product)
-              .orderBy(sort)
-              .limit(20)
-              .offset(page)
-              .fetch();
-    }
-
-    return products.stream().map(product ->
-            String.format("%s : %,d원", product.getName(), product.getPrice())).toList();
+    return PageDto.from(productRepository.searchAll(page, keyword, category, sortType, asc));
   }
 
   @Transactional
   public ProductDto updateProduct(ProductUpdateForm form) {
-    Product product = findProductByCode(form.getCode());
+    Product product = productRepository.searchByCode(form.getCode());
     setProductFromForm(form, product);
     return ProductDto.from(product);
   }
 
   @Transactional
   public ProductDetailDto updateProductDetail(ProductDetailUpdateForm form) {
-    Product product = findProductByCode(form.getCode());
-    ProductDetail detail = findProductDetailByProductAndSize(product, form.getSize());
+    Product product = productRepository.searchByCode(form.getCode());
+    ProductDetail productDetail = product.getDetails().stream()
+            .filter(detail -> detail.getSize().equals(form.getSize().toUpperCase()))
+            .findFirst().orElse(null);
 
-    setProductDetailFromForm(form, detail, product);
-    return ProductDetailDto.from(detail);
+    if (productDetail == null) {
+      throw new CustomException(NOT_FOUND_SIZE);
+    }
+
+    setProductDetailFromForm(form, productDetail, product);
+    return ProductDetailDto.from(productDetail);
   }
 
   @Transactional
   public ProductDto deleteProduct(String code) {
-    Product product = findProductByCode(code);
+    Product product = productRepository.searchByCode(code);
     productRepository.deleteByCode(code);
     return ProductDto.from(product);
   }
 
   @Transactional
   public ProductDetailDto deleteProductDetail(ProductDetailUpdateForm form) {
-    Product product = findProductByCode(form.getCode());
-    ProductDetail detail = findProductDetailByProductAndSize(product, form.getSize());
-    productDetailRepository.delete(detail);
-    return ProductDetailDto.from(detail);
+    Product product = productRepository.searchByCode(form.getCode());
+    ProductDetail productDetail = product.getDetails().stream()
+            .filter(detail -> detail.getSize().equals(form.getSize().toUpperCase()))
+            .findFirst().orElse(null);
+
+    if (productDetail == null) {
+      throw new CustomException(NOT_FOUND_SIZE);
+    }
+
+    productDetailRepository.delete(productDetail);
+    return ProductDetailDto.from(productDetail);
   }
 
   private void setProductFromForm(ProductUpdateForm form, Product product) {
@@ -157,11 +126,13 @@ public class ProductService {
       product.setPrice(Long.valueOf(form.getPrice()));
     }
     if (form.getCategoryType() != null) {
-      product.setCategoryType(CategoryType.fromString(form.getCategoryType()));
+      product.setCategoryType(form.getCategoryType());
     }
   }
 
-  private void setProductDetailFromForm(ProductDetailUpdateForm form, ProductDetail detail, Product product) {
+  private void setProductDetailFromForm(ProductDetailUpdateForm form,
+                                        ProductDetail detail,
+                                        Product product) {
     if (form.getChangeSize() != null) {
       for (ProductDetail productDetail : product.getDetails()) {
         if (productDetail.getSize().equals(form.getChangeSize())) {
@@ -170,20 +141,7 @@ public class ProductService {
       }
       detail.setSize(form.getChangeSize().toUpperCase());
     }
-    if (form.getQuantity() != null) {
-      detail.setQuantity(Integer.valueOf(form.getQuantity()));
-    }
+    detail.setQuantity(form.getQuantity());
   }
 
-  private ProductDetail findProductDetailByProductAndSize(Product product, String size) {
-    return product.getDetails().stream()
-            .filter(detail -> detail.getSize().equals(size.toUpperCase()))
-            .findFirst()
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SIZE));
-  }
-
-  private Product findProductByCode(String code) {
-    return productRepository.findByCode(code)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
-  }
 }

--- a/src/test/java/com/zb/ecommerce/service/CartServiceTest.java
+++ b/src/test/java/com/zb/ecommerce/service/CartServiceTest.java
@@ -1,0 +1,552 @@
+package com.zb.ecommerce.service;
+
+import com.zb.ecommerce.domain.dto.CartProductDto;
+import com.zb.ecommerce.domain.form.CartAddForm;
+import com.zb.ecommerce.domain.form.CartUpdateForm;
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.model.CartProduct;
+import com.zb.ecommerce.model.Member;
+import com.zb.ecommerce.model.Product;
+import com.zb.ecommerce.model.ProductDetail;
+import com.zb.ecommerce.repository.CartProductRepository;
+import com.zb.ecommerce.repository.MemberRepository;
+import com.zb.ecommerce.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.zb.ecommerce.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private CartProductRepository cartProductRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @InjectMocks
+  private CartService cartService;
+
+
+  CartAddForm cartAddForm = CartAddForm.builder()
+          .productCode("shoes_mk1")
+          .size("L")
+          .quantity("1")
+          .build();
+
+
+  @Test
+  @DisplayName("카트 상품 추가")
+  void addProductToCart1() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .cart(new ArrayList<>())
+                    .build()));
+
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .price(57000L)
+                    .code("shoes_mk1")
+                    .categoryType(CategoryType.SHOES)
+                    .description("넘나 이쁜 신발")
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    given(cartProductRepository.save(any()))
+            .willReturn(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("L")
+                                    .quantity(5)
+                                    .build()))
+                            .build())
+                    .size("L")
+                    .quantity(1)
+                    .build());
+
+    //when
+    CartProductDto result = cartService.addProductToCart("email", cartAddForm);
+    //then
+
+    assertEquals(1L, result.getId());
+    assertEquals("신발", result.getProductName());
+    assertEquals("L", result.getSize());
+    assertEquals(1, result.getQuantity());
+
+    verify(cartProductRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("카트 상품 추가(이미 카트에 상품이 있음)")
+  void addProductToCart2() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .cart(List.of(CartProduct.builder()
+                            .id(1L)
+                            .product(Product.builder()
+                                    .id(1L)
+                                    .name("신발")
+                                    .price(57000L)
+                                    .code("shoes_mk1")
+                                    .categoryType(CategoryType.SHOES)
+                                    .description("넘나 이쁜 신발")
+                                    .details(List.of(ProductDetail.builder()
+                                            .size("L")
+                                            .quantity(5)
+                                            .build()))
+                                    .build())
+                            .size("L")
+                            .quantity(1)
+                            .build()))
+                    .build()));
+
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .price(57000L)
+                    .code("shoes_mk1")
+                    .categoryType(CategoryType.SHOES)
+                    .description("넘나 이쁜 신발")
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    given(cartProductRepository.findByMemberAndProductAndSize(any(), any(), anyString()))
+            .willReturn(Optional.of(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("L")
+                                    .quantity(5)
+                                    .build()))
+                            .build())
+                    .size("L")
+                    .quantity(1)
+                    .build()));
+
+    //when
+    CartProductDto result = cartService.addProductToCart("email", cartAddForm);
+    //then
+
+    assertEquals(1L, result.getId());
+    assertEquals("신발", result.getProductName());
+    assertEquals("L", result.getSize());
+    assertEquals(2, result.getQuantity());
+
+    verify(cartProductRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("카트 상품 추가 실패(잘못된 이메일 입력)")
+  void addProductToCartFailure1() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.empty());
+
+    try {
+      //when
+      cartService.addProductToCart("email", cartAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_MEMBER, e.getErrorCode());
+    }
+    verify(cartProductRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("카트 상품 추가 실패(잘못된 코드 입력)")
+  void addProductToCartFailure2() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .build()));
+
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.empty());
+    try {
+      //when
+      cartService.addProductToCart("email", cartAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_PRODUCT, e.getErrorCode());
+    }
+    verify(cartProductRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("카트 상품 추가 실패(잘못된 사이즈 입력)")
+  void addProductToCartFailure3() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .build()));
+
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .price(57000L)
+                    .code("shoes_mk1")
+                    .categoryType(CategoryType.SHOES)
+                    .description("넘나 이쁜 신발")
+                    .details(List.of(ProductDetail.builder()
+                            .size("M")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+
+    try {
+      //when
+      cartService.addProductToCart("email", cartAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_SIZE, e.getErrorCode());
+    }
+    verify(cartProductRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("카트 상품 추가 실패(이미 카트에 상품이 있고 상품 갯수가 부족함)")
+  void addProductToCartFailure4() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .cart(List.of(CartProduct.builder()
+                            .id(1L)
+                            .product(Product.builder()
+                                    .id(1L)
+                                    .name("신발")
+                                    .price(57000L)
+                                    .code("shoes_mk1")
+                                    .categoryType(CategoryType.SHOES)
+                                    .description("넘나 이쁜 신발")
+                                    .details(List.of(ProductDetail.builder()
+                                            .size("L")
+                                            .quantity(1)
+                                            .build()))
+                                    .build())
+                            .size("L")
+                            .quantity(1)
+                            .build()))
+                    .build()));
+
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .price(57000L)
+                    .code("shoes_mk1")
+                    .categoryType(CategoryType.SHOES)
+                    .description("넘나 이쁜 신발")
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(1)
+                            .build()))
+                    .build()));
+
+
+    given(cartProductRepository.findByMemberAndProductAndSize(any(), any(), anyString()))
+            .willReturn(Optional.of(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("L")
+                                    .quantity(1)
+                                    .build()))
+                            .build())
+                    .size("L")
+                    .quantity(1)
+                    .build()));
+
+
+    try {
+      //when
+      cartService.addProductToCart("email", cartAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_ENOUGH_PRODUCT, e.getErrorCode());
+    }
+    verify(cartProductRepository, times(0)).save(any());
+  }
+
+  //-------
+
+  @Test
+  @DisplayName("카트에 모든 상품 확인")
+  void getAllCartProducts1() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .cart(List.of(CartProduct.builder()
+                            .id(1L)
+                            .product(Product.builder()
+                                    .id(1L)
+                                    .name("신발")
+                                    .price(57000L)
+                                    .build())
+                            .size("L")
+                            .quantity(2)
+                            .build(), CartProduct.builder()
+                            .id(2L)
+                            .product(Product.builder()
+                                    .id(2L)
+                                    .name("벨트")
+                                    .price(27000L)
+                                    .build())
+                            .size("M")
+                            .quantity(1)
+                            .build()))
+                    .build()));
+    //when
+    List<CartProductDto> result = cartService.getAllCartProducts("email");
+    //then
+    assertEquals(2, result.size());
+    assertEquals(1L, result.get(0).getId());
+    assertEquals("신발", result.get(0).getProductName());
+    assertEquals("L", result.get(0).getSize());
+    assertEquals(2, result.get(0).getQuantity());
+  }
+
+
+  @Test
+  @DisplayName("카트에 모든 상품 확인(카트에 아무것도 없음)")
+  void getAllCartProducts2() {
+    //given
+    given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(Member.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .cart(new ArrayList<>())
+                    .build()));
+    //when
+    List<CartProductDto> result = cartService.getAllCartProducts("email");
+    //then
+    assertEquals(0, result.size());
+  }
+
+  //----------
+
+  @Test
+  @DisplayName("카드 상품 갯수 수정")
+  void updateCartProduct() {
+    //given
+    given(cartProductRepository.findById(anyLong()))
+            .willReturn(Optional.of(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("M")
+                                    .quantity(5)
+                                    .build()))
+                            .build())
+                    .size("M")
+                    .quantity(1)
+                    .build()));
+
+    CartUpdateForm form = CartUpdateForm.builder()
+            .id(1L)
+            .size("M")
+            .quantity("2")
+            .build();
+    //when
+    CartProductDto result = cartService.updateProductToCart(form);
+    //then
+    assertEquals(2, result.getQuantity());
+  }
+
+  @Test
+  @DisplayName("카드 상품 갯수 수정 실패(잘못된 아이디 입력)")
+  void updateCartProductFailure1() {
+    //given
+    given(cartProductRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+    CartUpdateForm form = CartUpdateForm.builder()
+            .id(1L)
+            .size("M")
+            .quantity("2")
+            .build();
+
+    try {
+      //when
+      cartService.updateProductToCart(form);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_CART_PRODUCT, e.getErrorCode());
+    }
+  }
+
+  @Test
+  @DisplayName("카드 상품 갯수 수정 실패(잘못된 사이즈 입력)")
+  void updateCartProductFailure2() {
+    //given
+    given(cartProductRepository.findById(anyLong()))
+            .willReturn(Optional.of(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("M")
+                                    .quantity(5)
+                                    .build()))
+                            .build())
+                    .size("M")
+                    .quantity(1)
+                    .build()));
+
+    CartUpdateForm form = CartUpdateForm.builder()
+            .id(1L)
+            .size("L")
+            .quantity("2")
+            .build();
+    try {
+      //when
+      cartService.updateProductToCart(form);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_SIZE, e.getErrorCode());
+    }
+  }
+
+  @Test
+  @DisplayName("카드 상품 갯수 수정 실패(상품 갯수 부족)")
+  void updateCartProductFailure3() {
+    //given
+    given(cartProductRepository.findById(anyLong()))
+            .willReturn(Optional.of(CartProduct.builder()
+                    .id(1L)
+                    .product(Product.builder()
+                            .id(1L)
+                            .name("신발")
+                            .price(57000L)
+                            .code("shoes_mk1")
+                            .categoryType(CategoryType.SHOES)
+                            .description("넘나 이쁜 신발")
+                            .details(List.of(ProductDetail.builder()
+                                    .size("M")
+                                    .quantity(5)
+                                    .build()))
+                            .build())
+                    .size("M")
+                    .quantity(1)
+                    .build()));
+
+    CartUpdateForm form = CartUpdateForm.builder()
+            .id(1L)
+            .size("M")
+            .quantity("10")
+            .build();
+    try {
+      //when
+      cartService.updateProductToCart(form);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_ENOUGH_PRODUCT, e.getErrorCode());
+    }
+  }
+
+  //----
+
+  @Test
+  @DisplayName("카트 상품 삭제")
+  void deleteCartProduct() {
+    //given
+    given(cartProductRepository.existsById(anyLong()))
+            .willReturn(true);
+    //when
+    cartService.deleteProductToCart(1L);
+    //then
+    verify(cartProductRepository, times(1)).deleteById(anyLong());
+  }
+
+  @Test
+  @DisplayName("카트 상품 삭제 실패(잘못된 ID입력)")
+  void deleteCartProductFailure() {
+    //given
+    given(cartProductRepository.existsById(anyLong()))
+            .willReturn(false);
+    try {
+      //when
+      cartService.deleteProductToCart(1L);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_CART_PRODUCT, e.getErrorCode());
+      verify(cartProductRepository, times(0)).deleteById(anyLong());
+    }
+
+  }
+
+
+}

--- a/src/test/java/com/zb/ecommerce/service/CartServiceTest.java
+++ b/src/test/java/com/zb/ecommerce/service/CartServiceTest.java
@@ -50,7 +50,7 @@ class CartServiceTest {
   CartAddForm cartAddForm = CartAddForm.builder()
           .productCode("shoes_mk1")
           .size("L")
-          .quantity("1")
+          .quantity(1)
           .build();
 
 
@@ -58,15 +58,15 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가")
   void addProductToCart1() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
                     .cart(new ArrayList<>())
-                    .build()));
+                    .build());
 
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .price(57000L)
@@ -77,7 +77,7 @@ class CartServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     given(cartProductRepository.save(any()))
             .willReturn(CartProduct.builder()
@@ -114,8 +114,8 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가(이미 카트에 상품이 있음)")
   void addProductToCart2() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
                     .cart(List.of(CartProduct.builder()
@@ -135,10 +135,10 @@ class CartServiceTest {
                             .size("L")
                             .quantity(1)
                             .build()))
-                    .build()));
+                    .build());
 
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .price(57000L)
@@ -149,7 +149,7 @@ class CartServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     given(cartProductRepository.findByMemberAndProductAndSize(any(), any(), anyString()))
             .willReturn(Optional.of(CartProduct.builder()
@@ -186,8 +186,8 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가 실패(잘못된 이메일 입력)")
   void addProductToCartFailure1() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.empty());
+    given(memberRepository.searchByEmail(anyString()))
+            .willThrow(new CustomException(NOT_FOUND_MEMBER));
 
     try {
       //when
@@ -203,14 +203,14 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가 실패(잘못된 코드 입력)")
   void addProductToCartFailure2() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
-                    .build()));
+                    .build());
 
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.empty());
+    given(productRepository.searchByCode(anyString()))
+            .willThrow(new CustomException(NOT_FOUND_PRODUCT));
     try {
       //when
       cartService.addProductToCart("email", cartAddForm);
@@ -225,14 +225,14 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가 실패(잘못된 사이즈 입력)")
   void addProductToCartFailure3() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
-                    .build()));
+                    .build());
 
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .price(57000L)
@@ -243,7 +243,7 @@ class CartServiceTest {
                             .size("M")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
 
     try {
@@ -260,8 +260,8 @@ class CartServiceTest {
   @DisplayName("카트 상품 추가 실패(이미 카트에 상품이 있고 상품 갯수가 부족함)")
   void addProductToCartFailure4() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
                     .cart(List.of(CartProduct.builder()
@@ -281,10 +281,10 @@ class CartServiceTest {
                             .size("L")
                             .quantity(1)
                             .build()))
-                    .build()));
+                    .build());
 
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .price(57000L)
@@ -295,7 +295,7 @@ class CartServiceTest {
                             .size("L")
                             .quantity(1)
                             .build()))
-                    .build()));
+                    .build());
 
 
     given(cartProductRepository.findByMemberAndProductAndSize(any(), any(), anyString()))
@@ -334,8 +334,8 @@ class CartServiceTest {
   @DisplayName("카트에 모든 상품 확인")
   void getAllCartProducts1() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
                     .cart(List.of(CartProduct.builder()
@@ -357,7 +357,7 @@ class CartServiceTest {
                             .size("M")
                             .quantity(1)
                             .build()))
-                    .build()));
+                    .build());
     //when
     List<CartProductDto> result = cartService.getAllCartProducts("email");
     //then
@@ -373,12 +373,12 @@ class CartServiceTest {
   @DisplayName("카트에 모든 상품 확인(카트에 아무것도 없음)")
   void getAllCartProducts2() {
     //given
-    given(memberRepository.findByEmail(anyString()))
-            .willReturn(Optional.of(Member.builder()
+    given(memberRepository.searchByEmail(anyString()))
+            .willReturn(Member.builder()
                     .id(1L)
                     .email("test@test.com")
                     .cart(new ArrayList<>())
-                    .build()));
+                    .build());
     //when
     List<CartProductDto> result = cartService.getAllCartProducts("email");
     //then
@@ -413,7 +413,7 @@ class CartServiceTest {
     CartUpdateForm form = CartUpdateForm.builder()
             .id(1L)
             .size("M")
-            .quantity("2")
+            .quantity(2)
             .build();
     //when
     CartProductDto result = cartService.updateProductToCart(form);
@@ -431,7 +431,7 @@ class CartServiceTest {
     CartUpdateForm form = CartUpdateForm.builder()
             .id(1L)
             .size("M")
-            .quantity("2")
+            .quantity(2)
             .build();
 
     try {
@@ -469,7 +469,7 @@ class CartServiceTest {
     CartUpdateForm form = CartUpdateForm.builder()
             .id(1L)
             .size("L")
-            .quantity("2")
+            .quantity(2)
             .build();
     try {
       //when
@@ -506,7 +506,7 @@ class CartServiceTest {
     CartUpdateForm form = CartUpdateForm.builder()
             .id(1L)
             .size("M")
-            .quantity("10")
+            .quantity(10)
             .build();
     try {
       //when

--- a/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
@@ -1,0 +1,553 @@
+package com.zb.ecommerce.service;
+
+import com.zb.ecommerce.domain.dto.ProductDetailDto;
+import com.zb.ecommerce.domain.dto.ProductDto;
+import com.zb.ecommerce.domain.form.ProductAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailAddForm;
+import com.zb.ecommerce.domain.form.ProductDetailUpdateForm;
+import com.zb.ecommerce.domain.form.ProductUpdateForm;
+import com.zb.ecommerce.domain.type.CategoryType;
+import com.zb.ecommerce.exception.CustomException;
+import com.zb.ecommerce.model.Product;
+import com.zb.ecommerce.model.ProductDetail;
+import com.zb.ecommerce.repository.ProductDetailRepository;
+import com.zb.ecommerce.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.zb.ecommerce.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private ProductDetailRepository productDetailRepository;
+
+  @InjectMocks
+  private ProductService productService;
+
+  ProductAddForm productAddForm = ProductAddForm.builder()
+          .name("신발")
+          .code("shoes_mk1")
+          .description("너무나 이쁜 신발")
+          .price("89000")
+          .category("shoes")
+          .build();
+
+  ProductDetailAddForm detailAddForm = ProductDetailAddForm.builder()
+          .code("shoes_mk1")
+          .size("M")
+          .quantity("5")
+          .build();
+
+
+
+  @Test
+  @DisplayName("상품 추가 성공")
+  void addProduct() {
+    //given
+    given(productRepository.existsByCode(anyString()))
+            .willReturn(false);
+    //when
+    productService.addProduct(productAddForm);
+    //then
+    verify(productRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("상품 추가 실패(이미 추가된 상품)")
+  void addProductFailure() {
+    //given
+    given(productRepository.existsByCode(anyString()))
+            .willReturn(true);
+    try {
+      //when
+      productService.addProduct(productAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(ALREADY_ADDED_PRODUCT, e.getErrorCode());
+      verify(productRepository, times(0)).save(any());
+    }
+  }
+
+  //-------
+
+  @Test
+  @DisplayName("상품 디테일 추가 성공")
+  void addProductDetail() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .code("shoes_mk1")
+                    .description("너무 이쁜 신발")
+                    .price(89000L)
+                    .categoryType(CategoryType.SHOES)
+                    .details(null)
+                    .build()));
+    //when
+    productService.addProductDetail(detailAddForm);
+    //then
+    verify(productDetailRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("상품 디테일 추가 실패(상품을 찾을 수 없음)")
+  void addProductDetailFailure1() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .code("shoes_mk1")
+                    .description("너무 이쁜 신발")
+                    .price(89000L)
+                    .categoryType(CategoryType.SHOES)
+                    .details(null)
+                    .build()));
+    try {
+      //when
+      productService.addProductDetail(detailAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(NOT_FOUND_PRODUCT, e.getErrorCode());
+      verify(productDetailRepository, times(0)).save(any());
+    }
+  }
+
+  @Test
+  @DisplayName("상품 디테일 추가 실패(이미 추가된 상품 디테일)")
+  void addProductDetailFailure2() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .id(1L)
+                    .name("신발")
+                    .code("shoes_mk1")
+                    .description("너무 이쁜 신발")
+                    .price(89000L)
+                    .categoryType(CategoryType.SHOES)
+                    .details(List.of(ProductDetail.builder()
+                            .size("M")
+                            .quantity(3)
+                            .build()))
+                    .build()));
+    try {
+      //when
+      productService.addProductDetail(detailAddForm);
+    } catch (CustomException e) {
+      //then
+      assertEquals(ALREADY_ADDED_SIZE, e.getErrorCode());
+      verify(productDetailRepository, times(0)).save(any());
+    }
+  }
+
+  //---------
+
+  @Test
+  @DisplayName("모든 상품 확인")
+  void getAllProduct() {
+    //given
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageable = PageRequest.of(0, 20, sort);
+    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
+            .name("신발")
+                    .price(89000L)
+            .details(List.of(ProductDetail.builder()
+                    .size("M")
+                    .quantity(3)
+                    .build()))
+            .build(),
+            Product.builder()
+                    .name("코트")
+                    .price(120000L)
+                    .details(new ArrayList<>())
+                    .build(),
+            Product.builder()
+                    .name("벨트")
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(0)
+                            .build()))
+                    .build()
+            ), pageable, 0);
+    given(productRepository.findAll(pageable))
+            .willReturn(expectedPage);
+    //when
+    List<String> result = productService.getAllProduct(0);
+    //then
+    assertEquals(List.of("신발 : 89,000", "(품절)코트 : 120,000", "(품절)벨트 : 32,000"), result);
+    verify(productRepository, times(1)).findAll(pageable);
+  }
+
+  @Test
+  @DisplayName("모든 상품 확인 (찾을 상품이 없음)")
+  void getAllProductFailure1() {
+    //given
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageable = PageRequest.of(0, 20, sort);
+    Page<Product> expectedPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
+    given(productRepository.findAll(pageable))
+            .willReturn(expectedPage);
+    //when
+    List<String> result = productService.getAllProduct(0);
+    //then
+    assertNull(result);
+    verify(productRepository, times(1)).findAll(pageable);
+  }
+
+  //-----------
+
+  @Test
+  @DisplayName("디테일 확인")
+  void getProductDetail() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("신발")
+                    .code("shoes_mk1")
+                    .categoryType(CategoryType.SHOES)
+                    .price(89000L)
+                    .details(List.of(ProductDetail.builder()
+                                    .size("M")
+                                    .quantity(3)
+                                    .build(),
+                            ProductDetail.builder()
+                                    .size("L")
+                                    .quantity(0)
+                                    .build()))
+                    .build()));
+    //when
+    ProductDto result = productService.getProductDetail("code");
+    //then
+    assertEquals("신발", result.getName());
+  }
+
+  @Test
+  @DisplayName("디테일 확인(디테일 없음)")
+  void getProductDetailFailure() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("신발")
+                    .price(89000L)
+                    .details(new ArrayList<>())
+                    .build()));
+    //when
+    ProductDto result = productService.getProductDetail("code");
+    //then
+    assertEquals(new ArrayList<>(), result.getDetails());
+  }
+
+  //---------
+
+  @Test
+  @DisplayName("모든 상품 확인(이름 정렬)(test에선 정렬이 되진 않음)")
+  void getAllProductSort() {
+    //given
+    Sort sort = Sort.by(Sort.Direction.DESC, "name");
+    Pageable pageable = PageRequest.of(0, 20, sort);
+    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
+                    .name("신발")
+                    .price(89000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("M")
+                            .quantity(3)
+                            .build()))
+                    .build(),
+            Product.builder()
+                    .name("코트")
+                    .price(120000L)
+                    .details(new ArrayList<>())
+                    .build(),
+            Product.builder()
+                    .name("벨트")
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(0)
+                            .build()))
+                    .build()
+    ), pageable, 0);
+    given(productRepository.findAll(pageable))
+            .willReturn(expectedPage);
+    //when
+    List<String> result = productService.getAllProductSort(0, "name", false);
+    //then
+    assertEquals(List.of("신발 : 89,000원", "코트 : 120,000원", "벨트 : 32,000원"),result);
+  }
+
+  //--------
+
+  @Test
+  @DisplayName("모든 상품 확인(카테고리 정렬)")
+  void getAllProductSortCategory() {
+    //given
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageable = PageRequest.of(0, 20, sort);
+    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
+            .name("벨트")
+            .categoryType(CategoryType.BELT)
+            .price(32000L)
+            .details(List.of(ProductDetail.builder()
+                    .size("L")
+                    .quantity(0)
+                    .build()))
+            .build()
+
+    ), pageable, 0);
+
+    given(productRepository.findAllByCategoryType(CategoryType.BELT, pageable))
+            .willReturn(expectedPage);
+    //when
+    List<String> result = productService.getAllProductSortCategory(0, "belt");
+    //then
+    assertEquals(List.of("벨트 : 32,000원"),result);
+  }
+
+  @Test
+  @DisplayName("모든 상품 확인(카테고리 정렬)(해당 카테고리 상품이 없음)")
+  void getAllProductSortCategory2() {
+    //given
+    Sort sort = Sort.by(Sort.Direction.ASC, "name");
+    Pageable pageable = PageRequest.of(0, 20, sort);
+    Page<Product> expectedPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
+
+    given(productRepository.findAllByCategoryType(CategoryType.BELT, pageable))
+            .willReturn(expectedPage);
+    //when
+    List<String> result = productService.getAllProductSortCategory(0, "belt");
+    //then
+    assertEquals(new ArrayList<>(),result);
+  }
+
+  //--------
+
+  @Test
+  @DisplayName("상품 수정")
+  void updateProduct() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .code("belt_mk1")
+                    .name("벨트")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .description("짱짱한 벨트")
+                    .details(new ArrayList<>())
+                    .build()));
+
+    ProductUpdateForm form = ProductUpdateForm.builder()
+            .name("신발")
+            .code("belt_mk1")
+            .changeCode("shoes_mk1")
+            .description("너무나 이쁜 신발")
+            .price("89000")
+            .categoryType("shoes")
+            .build();
+    //when
+    ProductDto result = productService.updateProduct(form);
+    //then
+    assertEquals("신발",result.getName());
+    assertEquals("shoes_mk1",result.getCode());
+    assertEquals("너무나 이쁜 신발",result.getDescription());
+    assertEquals(CategoryType.SHOES, result.getCategoryType());
+    assertEquals(89000L,result.getPrice());
+  }
+
+  @Test
+  @DisplayName("상품 수정(price, name 빼고 진행)")
+  void updateProductFailure1() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .code("belt_mk1")
+                    .name("벨트")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .description("짱짱한 벨트")
+                    .details(new ArrayList<>())
+                    .build()));
+
+    ProductUpdateForm form = ProductUpdateForm.builder()
+            .code("belt_mk1")
+            .changeCode("shoes_mk1")
+            .categoryType("shoes")
+            .description("너무나 이쁜 신발")
+            .build();
+    //when
+    ProductDto result = productService.updateProduct(form);
+    //then
+    assertEquals("벨트",result.getName());
+    assertEquals("shoes_mk1",result.getCode());
+    assertEquals("너무나 이쁜 신발",result.getDescription());
+    assertEquals(CategoryType.SHOES,result.getCategoryType());
+    assertEquals(32000L,result.getPrice());
+  }
+
+  //-------
+
+  @Test
+  @DisplayName("디테일 수정")
+  void updateProductDetail() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("벨트")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
+            .code("belt_mk1")
+            .size("L")
+            .changeSize("M")
+            .quantity("10")
+            .build();
+
+    //when
+    ProductDetailDto result = productService.updateProductDetail(form);
+    //then
+    assertEquals("M",result.getSize());
+    assertEquals(10,result.getQuantity());
+  }
+
+  @Test
+  @DisplayName("디테일 수정(quantity만 수정)")
+  void updateProductDetail2() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("벨트")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
+            .code("belt_mk1")
+            .size("L")
+            .quantity("10")
+            .build();
+
+    //when
+    ProductDetailDto result = productService.updateProductDetail(form);
+    //then
+    assertEquals("L",result.getSize());
+    assertEquals(10,result.getQuantity());
+  }
+
+  @Test
+  @DisplayName("디테일 수정 실패(맞는 size가 없음)")
+  void updateProductDetailFailure() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("벨트")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("M")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
+            .code("belt_mk1")
+            .size("L")
+            .quantity("10")
+            .build();
+
+    try {
+      //when
+      productService.updateProductDetail(form);
+    } catch (CustomException e){
+      //then
+      assertEquals(NOT_FOUND_SIZE, e.getErrorCode());
+    }
+  }
+
+  //------
+
+  @Test
+  @DisplayName("상품 삭제")
+  void deleteProduct() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("벨트")
+                    .code("belt_mk1")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+    //when
+    productService.deleteProduct("belt_mk1");
+    //then
+    verify(productRepository, times(1)).findByCode(anyString());
+    verify(productRepository, times(1)).deleteByCode(anyString());
+  }
+
+//-----
+
+  @Test
+  @DisplayName("상품 디테일 삭제")
+  void deleteProductDetail() {
+    //given
+    given(productRepository.findByCode(anyString()))
+            .willReturn(Optional.of(Product.builder()
+                    .name("벨트")
+                    .code("belt_mk1")
+                    .categoryType(CategoryType.BELT)
+                    .price(32000L)
+                    .details(List.of(ProductDetail.builder()
+                            .size("L")
+                            .quantity(5)
+                            .build()))
+                    .build()));
+
+    ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
+            .code("belt_mk1")
+            .size("L")
+            .build();
+    //when
+    ProductDetailDto result = productService.deleteProductDetail(form);
+
+    //then
+    assertEquals("L",result.getSize());
+    assertEquals(5,result.getQuantity());
+  }
+
+}

--- a/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +25,6 @@ import java.util.Optional;
 
 import static com.zb.ecommerce.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -51,7 +49,7 @@ class ProductServiceTest {
           .code("shoes_mk1")
           .description("너무나 이쁜 신발")
           .price("89000")
-          .category("shoes")
+          .category(CategoryType.SHOES)
           .build();
 
   ProductDetailAddForm detailAddForm = ProductDetailAddForm.builder()
@@ -163,62 +161,7 @@ class ProductServiceTest {
     }
   }
 
-  //---------
-
-  @Test
-  @DisplayName("모든 상품 확인")
-  void getAllProduct() {
-    //given
-    Sort sort = Sort.by(Sort.Direction.ASC, "name");
-    Pageable pageable = PageRequest.of(0, 20, sort);
-    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
-            .name("신발")
-                    .price(89000L)
-            .details(List.of(ProductDetail.builder()
-                    .size("M")
-                    .quantity(3)
-                    .build()))
-            .build(),
-            Product.builder()
-                    .name("코트")
-                    .price(120000L)
-                    .details(new ArrayList<>())
-                    .build(),
-            Product.builder()
-                    .name("벨트")
-                    .price(32000L)
-                    .details(List.of(ProductDetail.builder()
-                            .size("L")
-                            .quantity(0)
-                            .build()))
-                    .build()
-            ), pageable, 0);
-    given(productRepository.findAll(pageable))
-            .willReturn(expectedPage);
-    //when
-    List<String> result = productService.getAllProduct(0);
-    //then
-    assertEquals(List.of("신발 : 89,000", "(품절)코트 : 120,000", "(품절)벨트 : 32,000"), result);
-    verify(productRepository, times(1)).findAll(pageable);
-  }
-
-  @Test
-  @DisplayName("모든 상품 확인 (찾을 상품이 없음)")
-  void getAllProductFailure1() {
-    //given
-    Sort sort = Sort.by(Sort.Direction.ASC, "name");
-    Pageable pageable = PageRequest.of(0, 20, sort);
-    Page<Product> expectedPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
-    given(productRepository.findAll(pageable))
-            .willReturn(expectedPage);
-    //when
-    List<String> result = productService.getAllProduct(0);
-    //then
-    assertNull(result);
-    verify(productRepository, times(1)).findAll(pageable);
-  }
-
-  //-----------
+  //-------
 
   @Test
   @DisplayName("디테일 확인")
@@ -261,89 +204,7 @@ class ProductServiceTest {
     assertEquals(new ArrayList<>(), result.getDetails());
   }
 
-  //---------
-
-  @Test
-  @DisplayName("모든 상품 확인(이름 정렬)(test에선 정렬이 되진 않음)")
-  void getAllProductSort() {
-    //given
-    Sort sort = Sort.by(Sort.Direction.DESC, "name");
-    Pageable pageable = PageRequest.of(0, 20, sort);
-    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
-                    .name("신발")
-                    .price(89000L)
-                    .details(List.of(ProductDetail.builder()
-                            .size("M")
-                            .quantity(3)
-                            .build()))
-                    .build(),
-            Product.builder()
-                    .name("코트")
-                    .price(120000L)
-                    .details(new ArrayList<>())
-                    .build(),
-            Product.builder()
-                    .name("벨트")
-                    .price(32000L)
-                    .details(List.of(ProductDetail.builder()
-                            .size("L")
-                            .quantity(0)
-                            .build()))
-                    .build()
-    ), pageable, 0);
-    given(productRepository.findAll(pageable))
-            .willReturn(expectedPage);
-    //when
-    List<String> result = productService.getAllProductSort(0, "name", false);
-    //then
-    assertEquals(List.of("신발 : 89,000원", "코트 : 120,000원", "벨트 : 32,000원"),result);
-  }
-
-  //--------
-
-  @Test
-  @DisplayName("모든 상품 확인(카테고리 정렬)")
-  void getAllProductSortCategory() {
-    //given
-    Sort sort = Sort.by(Sort.Direction.ASC, "name");
-    Pageable pageable = PageRequest.of(0, 20, sort);
-    Page<Product> expectedPage = new PageImpl<>(List.of(Product.builder()
-            .name("벨트")
-            .categoryType(CategoryType.BELT)
-            .price(32000L)
-            .details(List.of(ProductDetail.builder()
-                    .size("L")
-                    .quantity(0)
-                    .build()))
-            .build()
-
-    ), pageable, 0);
-
-    given(productRepository.findAllByCategoryType(CategoryType.BELT, pageable))
-            .willReturn(expectedPage);
-    //when
-    List<String> result = productService.getAllProductSortCategory(0, "belt");
-    //then
-    assertEquals(List.of("벨트 : 32,000원"),result);
-  }
-
-  @Test
-  @DisplayName("모든 상품 확인(카테고리 정렬)(해당 카테고리 상품이 없음)")
-  void getAllProductSortCategory2() {
-    //given
-    Sort sort = Sort.by(Sort.Direction.ASC, "name");
-    Pageable pageable = PageRequest.of(0, 20, sort);
-    Page<Product> expectedPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
-
-    given(productRepository.findAllByCategoryType(CategoryType.BELT, pageable))
-            .willReturn(expectedPage);
-    //when
-    List<String> result = productService.getAllProductSortCategory(0, "belt");
-    //then
-    assertEquals(new ArrayList<>(),result);
-  }
-
-  //--------
+  //-------
 
   @Test
   @DisplayName("상품 수정")
@@ -520,7 +381,7 @@ class ProductServiceTest {
     verify(productRepository, times(1)).deleteByCode(anyString());
   }
 
-//-----
+  //-----
 
   @Test
   @DisplayName("상품 디테일 삭제")

--- a/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/ecommerce/service/ProductServiceTest.java
@@ -21,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.zb.ecommerce.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,9 +54,8 @@ class ProductServiceTest {
   ProductDetailAddForm detailAddForm = ProductDetailAddForm.builder()
           .code("shoes_mk1")
           .size("M")
-          .quantity("5")
+          .quantity(5)
           .build();
-
 
 
   @Test
@@ -94,16 +92,16 @@ class ProductServiceTest {
   @DisplayName("상품 디테일 추가 성공")
   void addProductDetail() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .code("shoes_mk1")
                     .description("너무 이쁜 신발")
                     .price(89000L)
                     .categoryType(CategoryType.SHOES)
-                    .details(null)
-                    .build()));
+                    .details(new ArrayList<>())
+                    .build());
     //when
     productService.addProductDetail(detailAddForm);
     //then
@@ -114,16 +112,16 @@ class ProductServiceTest {
   @DisplayName("상품 디테일 추가 실패(상품을 찾을 수 없음)")
   void addProductDetailFailure1() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .code("shoes_mk1")
                     .description("너무 이쁜 신발")
                     .price(89000L)
                     .categoryType(CategoryType.SHOES)
-                    .details(null)
-                    .build()));
+                    .details(new ArrayList<>())
+                    .build());
     try {
       //when
       productService.addProductDetail(detailAddForm);
@@ -138,8 +136,8 @@ class ProductServiceTest {
   @DisplayName("상품 디테일 추가 실패(이미 추가된 상품 디테일)")
   void addProductDetailFailure2() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .id(1L)
                     .name("신발")
                     .code("shoes_mk1")
@@ -150,7 +148,7 @@ class ProductServiceTest {
                             .size("M")
                             .quantity(3)
                             .build()))
-                    .build()));
+                    .build());
     try {
       //when
       productService.addProductDetail(detailAddForm);
@@ -167,8 +165,8 @@ class ProductServiceTest {
   @DisplayName("디테일 확인")
   void getProductDetail() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("신발")
                     .code("shoes_mk1")
                     .categoryType(CategoryType.SHOES)
@@ -181,7 +179,7 @@ class ProductServiceTest {
                                     .size("L")
                                     .quantity(0)
                                     .build()))
-                    .build()));
+                    .build());
     //when
     ProductDto result = productService.getProductDetail("code");
     //then
@@ -192,12 +190,12 @@ class ProductServiceTest {
   @DisplayName("디테일 확인(디테일 없음)")
   void getProductDetailFailure() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("신발")
                     .price(89000L)
                     .details(new ArrayList<>())
-                    .build()));
+                    .build());
     //when
     ProductDto result = productService.getProductDetail("code");
     //then
@@ -210,15 +208,15 @@ class ProductServiceTest {
   @DisplayName("상품 수정")
   void updateProduct() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .code("belt_mk1")
                     .name("벨트")
                     .categoryType(CategoryType.BELT)
                     .price(32000L)
                     .description("짱짱한 벨트")
                     .details(new ArrayList<>())
-                    .build()));
+                    .build());
 
     ProductUpdateForm form = ProductUpdateForm.builder()
             .name("신발")
@@ -226,46 +224,46 @@ class ProductServiceTest {
             .changeCode("shoes_mk1")
             .description("너무나 이쁜 신발")
             .price("89000")
-            .categoryType("shoes")
+            .categoryType(CategoryType.SHOES)
             .build();
     //when
     ProductDto result = productService.updateProduct(form);
     //then
-    assertEquals("신발",result.getName());
-    assertEquals("shoes_mk1",result.getCode());
-    assertEquals("너무나 이쁜 신발",result.getDescription());
+    assertEquals("신발", result.getName());
+    assertEquals("shoes_mk1", result.getCode());
+    assertEquals("너무나 이쁜 신발", result.getDescription());
     assertEquals(CategoryType.SHOES, result.getCategoryType());
-    assertEquals(89000L,result.getPrice());
+    assertEquals(89000L, result.getPrice());
   }
 
   @Test
   @DisplayName("상품 수정(price, name 빼고 진행)")
   void updateProductFailure1() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .code("belt_mk1")
                     .name("벨트")
                     .categoryType(CategoryType.BELT)
                     .price(32000L)
                     .description("짱짱한 벨트")
                     .details(new ArrayList<>())
-                    .build()));
+                    .build());
 
     ProductUpdateForm form = ProductUpdateForm.builder()
             .code("belt_mk1")
             .changeCode("shoes_mk1")
-            .categoryType("shoes")
+            .categoryType(CategoryType.SHOES)
             .description("너무나 이쁜 신발")
             .build();
     //when
     ProductDto result = productService.updateProduct(form);
     //then
-    assertEquals("벨트",result.getName());
-    assertEquals("shoes_mk1",result.getCode());
-    assertEquals("너무나 이쁜 신발",result.getDescription());
-    assertEquals(CategoryType.SHOES,result.getCategoryType());
-    assertEquals(32000L,result.getPrice());
+    assertEquals("벨트", result.getName());
+    assertEquals("shoes_mk1", result.getCode());
+    assertEquals("너무나 이쁜 신발", result.getDescription());
+    assertEquals(CategoryType.SHOES, result.getCategoryType());
+    assertEquals(32000L, result.getPrice());
   }
 
   //-------
@@ -274,8 +272,8 @@ class ProductServiceTest {
   @DisplayName("디테일 수정")
   void updateProductDetail() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("벨트")
                     .categoryType(CategoryType.BELT)
                     .price(32000L)
@@ -283,28 +281,28 @@ class ProductServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
             .code("belt_mk1")
             .size("L")
             .changeSize("M")
-            .quantity("10")
+            .quantity(10)
             .build();
 
     //when
     ProductDetailDto result = productService.updateProductDetail(form);
     //then
-    assertEquals("M",result.getSize());
-    assertEquals(10,result.getQuantity());
+    assertEquals("M", result.getSize());
+    assertEquals(10, result.getQuantity());
   }
 
   @Test
   @DisplayName("디테일 수정(quantity만 수정)")
   void updateProductDetail2() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("벨트")
                     .categoryType(CategoryType.BELT)
                     .price(32000L)
@@ -312,27 +310,27 @@ class ProductServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
             .code("belt_mk1")
             .size("L")
-            .quantity("10")
+            .quantity(10)
             .build();
 
     //when
     ProductDetailDto result = productService.updateProductDetail(form);
     //then
-    assertEquals("L",result.getSize());
-    assertEquals(10,result.getQuantity());
+    assertEquals("L", result.getSize());
+    assertEquals(10, result.getQuantity());
   }
 
   @Test
   @DisplayName("디테일 수정 실패(맞는 size가 없음)")
   void updateProductDetailFailure() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("벨트")
                     .categoryType(CategoryType.BELT)
                     .price(32000L)
@@ -340,18 +338,18 @@ class ProductServiceTest {
                             .size("M")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
             .code("belt_mk1")
             .size("L")
-            .quantity("10")
+            .quantity(10)
             .build();
 
     try {
       //when
       productService.updateProductDetail(form);
-    } catch (CustomException e){
+    } catch (CustomException e) {
       //then
       assertEquals(NOT_FOUND_SIZE, e.getErrorCode());
     }
@@ -363,8 +361,8 @@ class ProductServiceTest {
   @DisplayName("상품 삭제")
   void deleteProduct() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("벨트")
                     .code("belt_mk1")
                     .categoryType(CategoryType.BELT)
@@ -373,11 +371,11 @@ class ProductServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
     //when
     productService.deleteProduct("belt_mk1");
     //then
-    verify(productRepository, times(1)).findByCode(anyString());
+    verify(productRepository, times(1)).searchByCode(anyString());
     verify(productRepository, times(1)).deleteByCode(anyString());
   }
 
@@ -387,8 +385,8 @@ class ProductServiceTest {
   @DisplayName("상품 디테일 삭제")
   void deleteProductDetail() {
     //given
-    given(productRepository.findByCode(anyString()))
-            .willReturn(Optional.of(Product.builder()
+    given(productRepository.searchByCode(anyString()))
+            .willReturn(Product.builder()
                     .name("벨트")
                     .code("belt_mk1")
                     .categoryType(CategoryType.BELT)
@@ -397,7 +395,7 @@ class ProductServiceTest {
                             .size("L")
                             .quantity(5)
                             .build()))
-                    .build()));
+                    .build());
 
     ProductDetailUpdateForm form = ProductDetailUpdateForm.builder()
             .code("belt_mk1")
@@ -407,8 +405,8 @@ class ProductServiceTest {
     ProductDetailDto result = productService.deleteProductDetail(form);
 
     //then
-    assertEquals("L",result.getSize());
-    assertEquals(5,result.getQuantity());
+    assertEquals("L", result.getSize());
+    assertEquals(5, result.getQuantity());
   }
 
 }


### PR DESCRIPTION
## 📋작업 내용
- 카트 상품 추가 기능
  - 카트에 같은 상품이 이미 담겨있는 경우 갯수만 추가
  - 상품 재고가 카트에 추가하려는 갯수보다 많아야 추가 가능
- 카트 상품 확인 기능
- 카트 상품 갯수 수정 기능
- 카트 상품 삭제 기능
### UPDATE
- QueryDsl을 사용해서 fetch join으로 N+1 문제를 해결
- QueryDsl의 로직을 product, member repository로 연결
- form에 Quantity를 String에서 Integer로 변경

## 📌PR 유형

어떤 변경사항이 있나요?
- [x] 새로운 기능 추가
- [x] 수정

## 📢공유사항
- cart를 member가 추가될 때 같이 생성하는 방향으로 구현했는데 괜찮은 방법인지 궁금합니다.
### UPDATE
- repositoryCustom을 만들어서 repository에 extends하는 방법이 괜찮은 방법일까요?
- productRepositoryCusmtomImpl의 searchByCode함수 쿼리에 size까지 추가해서 db에서 호출하고 null값이 나오면 product가 없는지 size가 없는지 확인이 어려워 쿼리에 size를 추가하지 않았습니다. 혹시 성능을 위해 size를 추가하는게 좋을까요?

## ✅PR 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
